### PR TITLE
config file, smtp, complete user management and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-#ignore file where JWT_SECRET_KEY gets imported by run.sh script
+#ignore config files 
 JWT_SECRET_KEY
+config.yml

--- a/project_W/__main__.py
+++ b/project_W/__main__.py
@@ -4,6 +4,7 @@ from project_W import create_app
 @click.command()
 @click.option("--host", default="localhost", show_default=True)
 @click.option("--port", default=8080, show_default=True)
-def main(host: str, port: int):
-    app = create_app()
+@click.option("--customConfigPath", required=False)
+def main(host: str, port: int, customconfigpath = None):
+    app = create_app(customConfigPath=customconfigpath)
     app.run(host=host, port=port)

--- a/project_W/__main__.py
+++ b/project_W/__main__.py
@@ -4,7 +4,6 @@ from project_W import create_app
 @click.command()
 @click.option("--host", default="localhost", show_default=True)
 @click.option("--port", default=8080, show_default=True)
-@click.option("--data-path", default=".", show_default=True)
-def main(host: str, port: int, data_path: str):
-    app = create_app(db_path=data_path)
+def main(host: str, port: int):
+    app = create_app()
     app.run(host=host, port=port)

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -59,6 +59,9 @@ def create_app() -> Flask:
 
     @app.post("/api/signup")
     def signup():
+        if app.config["loginSecurity"]["disableSignup"]:
+            return jsonify(message="signup of new accounts is disabled on this server"), 400
+
         email = request.form['email']
         password = request.form['password']
         logger.info(f"Signup request from {email}")

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -83,8 +83,9 @@ def create_app(customConfigPath: str|None = None) -> Flask:
     @app.get("/api/activate")
     def activate():
         if(token := request.args.get("token", type=str)):
-            return activate_user(token)
-        else: return "You need a token to activate a users email", 400
+            message, code = activate_user(token)
+            return jsonify(message=message), code
+        else: return jsonify(message="You need a token to activate a users email"), 400
 
     @app.post("/api/login")
     def login():

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -4,7 +4,7 @@ from typing import Optional
 from flask import Flask, jsonify, request
 from flask_jwt_extended import JWTManager, create_access_token, current_user, jwt_required
 from .logger import get_logger
-from .model import User, add_new_user, delete_user, update_user_password, update_user_email, db
+from .model import User, add_new_user, delete_user, update_user_password, update_user_email, db, _send_email
 from .config import loadConfig
 
 
@@ -31,9 +31,6 @@ def create_app() -> Flask:
     app.config["JWT_ACCESS_TOKEN_EXPIRES"] = datetime.timedelta(minutes=60)
     app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{app.config['DB_PATH']}/database.db"
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-
-    print(app.config["SMTP_SERVER"]["domain"])
-    print(app.config["SMTP_SERVER"]["sender"])
 
     jwt = JWTManager(app)
     db.init_app(app)

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -8,7 +8,7 @@ from .logger import get_logger
 from .model import User, add_new_user, delete_user, db, activate_user, send_activation_email, send_password_reset_email, reset_user_password, is_valid_email, is_valid_password
 from .config import loadConfig
 
-def create_app(customConfigPath: str|None = None) -> Flask:
+def create_app(customConfigPath: Optional[str] = None) -> Flask:
     logger = get_logger("project-W")
     app = Flask("project-W")
 

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -104,7 +104,7 @@ def create_app() -> Flask:
                 return jsonify(message="No user exists with that email"), 400
         else:
             logger.info(f"Requested user info for {user.email}")
-        return jsonify(email=user.email, is_admin=user.is_admin)
+        return jsonify(email=user.email, is_admin=user.is_admin, activated=user.activated)
 
     @app.post("/api/deleteUser")
     @jwt_required()

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -4,7 +4,7 @@ from typing import Optional
 from flask import Flask, jsonify, request
 from flask_jwt_extended import JWTManager, create_access_token, current_user, jwt_required
 from .logger import get_logger
-from .model import User, add_new_user, delete_user, update_user_password, update_user_email, db, activate_user
+from .model import User, add_new_user, delete_user, db, activate_user, send_activation_email
 from .config import loadConfig
 
 
@@ -164,8 +164,8 @@ def create_app() -> Flask:
 
         new_password = request.form['new_password']
         logger.info(f"request to modify user password from {thisUser.email} for user {toModify.email}")
-        message, code = update_user_password(toModify, new_password)
-        return jsonify(message=message), code
+        toModify.set_password_unchecked(new_password)
+        return jsonify(message="Successfully updated user password"), 200
 
     @app.post("/api/changeUserEmail")
     @jwt_required()
@@ -195,8 +195,8 @@ def create_app() -> Flask:
 
         new_email = request.form['new_email']
         logger.info(f"request to modify user email from {thisUser.email} for user {toModify.email}")
-        message, code = update_user_email(toModify, new_email)
-        return jsonify(message=message), code
+        send_activation_email(toModify.email, new_email)
+        return jsonify(message="Successfully requested email address change. Please confirm your new address be clicking on the link provided in the email we just sent you"), 200
 
     with app.app_context():
         db.create_all()

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -75,7 +75,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
         if not is_valid_email(email): 
             return jsonify(message=f"'{email}' is not a valid email address", allowedEmailDomains=app.config["loginSecurity"]["allowedEmailDomains"]), 400
         if not is_valid_password(password): 
-            return jsonify(message="password invalid. The password needs to have at least one lower case letter, higher case letter, number, special character and at least 12 characters in total"), 400
+            return jsonify(message="password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"), 400
 
         message, code = add_new_user(email, password, False)
         return jsonify(message=message), code
@@ -126,7 +126,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
 
         msg, code = "", 0
         if not is_valid_password(newPassword): 
-            msg, code = "password invalid. The password needs to have at least one lower case letter, higher case letter, number, special character and at least 12 characters in total", 400
+            msg, code = "password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total", 400
         elif(token := request.args.get("token", type=str)):
             msg, code = reset_user_password(token, newPassword)
         else: msg, code = "You need a token to reset a users password", 400
@@ -209,7 +209,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
 
         new_password = request.form['new_password']
         if not is_valid_password(password): 
-            return jsonify(message="password invalid. The password needs to have at least one lower case letter, higher case letter, number, special character and at least 12 characters in total"), 400
+            return jsonify(message="password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"), 400
 
         logger.info(f"request to modify user password from {thisUser.email} for user {toModify.email}")
         toModify.set_password_unchecked(new_password)
@@ -247,7 +247,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
 
         logger.info(f"request to modify user email from {thisUser.email} to {toModify.email}")
         if send_activation_email(toModify.email, new_email): 
-            return jsonify(message="Successfully requested email address change. Please confirm your new address be clicking on the link provided in the email we just sent you"), 200
+            return jsonify(message="Successfully requested email address change. Please confirm your new address by clicking on the link provided in the email we just sent you"), 200
         else:
             return jsonify(message=f"Failed to send activation email to {new_email}. Email address may not exist"), 400
 

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -7,16 +7,15 @@ from .logger import get_logger
 from .model import User, add_new_user, delete_user, db, activate_user, send_activation_email
 from .config import loadConfig
 
-
 def create_app() -> Flask:
     logger = get_logger("project-W")
     app = Flask("project-W")
 
     #load config from default values < config file < env vars (latest has highest precedence)
-    loadConfig(app)
+    app.config.update(loadConfig())
 
     #check syntax of JWT_SECRET_KEY and update if necessary
-    JWT_SECRET_KEY = app.config["JWT_SECRET_KEY"]
+    JWT_SECRET_KEY = app.config["loginSecurity"]["sessionSecretKey"]
     if JWT_SECRET_KEY is not None and len(JWT_SECRET_KEY) > 16:
         logger.info("Setting JWT_SECRET_KEY from supplied config or env var")
     else:
@@ -28,8 +27,8 @@ def create_app() -> Flask:
         app.config["JWT_SECRET_KEY"] = JWT_SECRET_KEY
 
     # tokens are by default valid for 1 hour
-    app.config["JWT_ACCESS_TOKEN_EXPIRES"] = datetime.timedelta(minutes=60)
-    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{app.config['DB_PATH']}/database.db"
+    app.config["JWT_ACCESS_TOKEN_EXPIRES"] = datetime.timedelta(minutes=app.config["loginSecurity"]["sessionExpirationTimeMinutes"])
+    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{app.config['databasePath']}/database.db"
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
     jwt = JWTManager(app)

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -4,7 +4,7 @@ from typing import Optional
 from flask import Flask, jsonify, request
 from flask_jwt_extended import JWTManager, create_access_token, current_user, jwt_required
 from .logger import get_logger
-from .model import User, add_new_user, delete_user, update_user_password, update_user_email, db, _send_email
+from .model import User, add_new_user, delete_user, update_user_password, update_user_email, db, activate_user
 from .config import loadConfig
 
 
@@ -13,7 +13,7 @@ def create_app() -> Flask:
     app = Flask("project-W")
 
     #load config from default values < config file < env vars (latest has highest precedence)
-    loadConfig(app, logger)
+    loadConfig(app)
 
     #check syntax of JWT_SECRET_KEY and update if necessary
     JWT_SECRET_KEY = app.config["JWT_SECRET_KEY"]
@@ -65,6 +65,12 @@ def create_app() -> Flask:
         logger.info(f"Signup request from {email}")
         message, code = add_new_user(email, password, False)
         return jsonify(message=message), code
+
+    @app.get("/api/activate")
+    def activate():
+        if(token := request.args.get("token", type=str)):
+            return activate_user(token)
+        else: return "You need a token to activate a users email", 400
 
     @app.post("/api/login")
     def login():

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -1,18 +1,24 @@
 import datetime
 import secrets
 from typing import Optional
+from pathlib import Path
 from flask import Flask, jsonify, request
 from flask_jwt_extended import JWTManager, create_access_token, current_user, jwt_required
 from .logger import get_logger
 from .model import User, add_new_user, delete_user, db, activate_user, send_activation_email, is_valid_email, is_valid_password
 from .config import loadConfig
 
-def create_app() -> Flask:
+def create_app(customConfigPath: str|None = None) -> Flask:
     logger = get_logger("project-W")
     app = Flask("project-W")
 
-    #load config from default values < config file < env vars (latest has highest precedence)
-    app.config.update(loadConfig())
+    #load config from additionalPaths (if not None) + defaultSearchDirs
+    if customConfigPath is None:
+        app.config.update(loadConfig())
+    else:
+        path = Path(customConfigPath)
+        if not path.is_dir(): path = path.parent
+        app.config.update(loadConfig(additionalPaths=[ path ]))
 
     #check syntax of JWT_SECRET_KEY and update if necessary
     JWT_SECRET_KEY = app.config["loginSecurity"]["sessionSecretKey"]
@@ -67,7 +73,7 @@ def create_app() -> Flask:
         logger.info(f"Signup request from {email}")
 
         if not is_valid_email(email): 
-            return jsonify(message=f"{email} is not a valid email address", allowedEmailDomains=app.config["loginSecurity"]["allowedEmailDomains"]), 400
+            return jsonify(message=f"'{email}' is not a valid email address", allowedEmailDomains=app.config["loginSecurity"]["allowedEmailDomains"]), 400
         if not is_valid_password(password): 
             return jsonify(message="password invalid. The password needs to have at least one lower case letter, higher case letter, number, special character and at least 12 characters in total"), 400
 
@@ -162,7 +168,7 @@ def create_app() -> Flask:
                 User.email == specifiedEmail).one_or_none()
             if not thisUser.is_admin:
                 logger.info(
-                    f"Non-admin tried to modify user {specifiedEmail}, denied")
+                    f"Non-admin tried to modify password of user {specifiedEmail}, denied")
                 return jsonify(message="You don't have permission to modify other users"), 403
             elif not specifiedUser:
                 logger.info(" -> Invalid user email")
@@ -206,7 +212,7 @@ def create_app() -> Flask:
 
         new_email = request.form['new_email']
         if not is_valid_email(new_email): 
-            return jsonify(message=f"{new_email} is not a valid email address", allowedEmailDomains=app.config["loginSecurity"]["allowedEmailDomains"]), 400
+            return jsonify(message=f"'{new_email}' is not a valid email address", allowedEmailDomains=app.config["loginSecurity"]["allowedEmailDomains"]), 400
 
         logger.info(f"request to modify user email from {thisUser.email} to {toModify.email}")
         if send_activation_email(toModify.email, new_email): 

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -31,9 +31,9 @@ DefaultValidatingValidator = extend_with_default(Draft202012Validator)
 schema = {
     "type": "object",
     "properties": {
-        "url": {
+        "clientURL": {
             "type": "string",
-            "pattern": r"^(http|https):\/\/(([a-z0-9\-]+\.)+[a-z0-9\-]+|localhost)(:[0-9]+)?$",
+            "pattern": r"^(http|https):\/\/(([a-zA-Z0-9\-]+\.)+[a-zA-Z0-9\-]+|localhost)(:[0-9]+)?((\/[a-zA-Z0-9\-]+)+)?$",
         },
         "databasePath": {
             "type": "string",
@@ -55,7 +55,7 @@ schema = {
                     "type": [ "array" ],
                     "items": {
                         "type": "string",
-                        "pattern": r"^([a-z0-9\-]+\.)+[a-z0-9\-]+$"
+                        "pattern": r"^([a-zA-Z0-9\-]+\.)+[a-zA-Z0-9\-]+$"
                     },
                     "default": []
                 },
@@ -72,7 +72,7 @@ schema = {
             "properties": {
                 "domain": {
                     "type": "string",
-                    "pattern": r"^([a-z0-9\-]+\.)+[a-z0-9\-]+|localhost$",
+                    "pattern": r"^([a-zA-Z0-9\-]+\.)+[a-zA-Z0-9\-]+|localhost$",
                 },
                 "port": {
                     "type": "integer",
@@ -101,7 +101,7 @@ schema = {
             "default": False
         }
     },
-    "required": [ "url", "smtpServer" ],
+    "required": [ "clientURL", "smtpServer" ],
     "additionalProperties": False
 }
 

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -1,11 +1,15 @@
 import yaml 
 import logging
 from pathlib import Path
-from flask import Flask
+import flask
+from project_W.logger import get_logger
+
+logger = get_logger("project_W")
 
 # define default config options 
 # default options will be overwritten later if they are defined in config.yml or env vars
 defaultConfig = {
+    "URL": "http://localhost:5000",
     "DB_PATH": ".",
     "JWT_SECRET_KEY": None,
     "SMTP_SERVER": {
@@ -17,7 +21,7 @@ defaultConfig = {
     }
 }
 
-def loadConfig(app: Flask, logger: logging.Logger):
+def loadConfig(app):
     #first set our app.config to the default values defined above
     app.config.update(defaultConfig)
 

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -58,6 +58,10 @@ schema = {
                         "pattern": r"^([a-z0-9\-]+\.)+[a-z0-9\-]+$"
                     },
                     "default": []
+                },
+                "disableSignup": {
+                    "type": "boolean",
+                    "default": False
                 }
             },
             "additionalProperties": False,

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -1,6 +1,7 @@
 import yaml 
 import logging
 from pathlib import Path
+from typing import Dict
 import flask
 from project_W.logger import get_logger
 
@@ -41,4 +42,9 @@ def loadConfig(app):
 
     #finally do the same thing for env variables (this means env vars have highest precedence)
     #we only load env variables with prefix "PROJECT-W". This prefix will be removed when storing var in app.config
+    fileConfig: Dict = app.config.copy()
     app.config.from_prefixed_env(prefix="PROJECT_W", loads=yaml.safe_load)
+    #the following makes sure that dicts inside our dict get updated and not overwritten. dicts inside dicts in our config are not supported
+    for name, value in fileConfig.items():
+        if isinstance(value, Dict): value.update(app.config[name])
+    app.config = fileConfig

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -77,16 +77,19 @@ schema = {
                 },
                 "secure": {
                     "type": "string",
-                    "pattern": r"^ssl|starttls$"
+                    "pattern": r"^ssl|starttls|unencrypted$"
                 },
                 "senderEmail": {
+                    "type": "string"
+                },
+                "username": {
                     "type": "string"
                 },
                 "password": {
                     "type": "string"
                 }
             },
-            "required": [ "domain", "port", "secure", "senderEmail", "password" ],
+            "required": [ "domain", "port", "secure", "senderEmail", "username", "password" ],
             "additionalProperties": False
         },
         "disableOptionValidation": {

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -11,10 +11,9 @@ defaultConfig = {
     "SMTP_SERVER": {
         "domain": None,
         "port": 587,
-        "secure": "tls",
-        "name": None,
+        "secure": "starttls",
+        "sender_email": None,
         "password": None,
-        "sender": None
     }
 }
 

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -1,52 +1,140 @@
-import yaml 
-import logging
 from pathlib import Path
 from typing import Dict
-import flask
+from jsonschema import Draft202012Validator, ValidationError, validators
+from platformdirs import user_data_dir, user_config_path, site_config_path
+from pyaml_env import parse_config
 from project_W.logger import get_logger
 
-logger = get_logger("project_W")
+programName = "project-W"
+logger = get_logger(programName)
 
-# define default config options 
-# default options will be overwritten later if they are defined in config.yml or env vars
-defaultConfig = {
-    "URL": "http://localhost:5000",
-    "DB_PATH": ".",
-    "JWT_SECRET_KEY": None,
-    "SMTP_SERVER": {
-        "domain": None,
-        "port": 587,
-        "secure": "starttls",
-        "sender_email": None,
-        "password": None,
-    }
+def extend_with_default(validator_class):
+    validate_properties = validator_class.VALIDATORS["properties"]
+
+    def set_defaults(validator, properties, instance, schema):
+        for property, subschema in properties.items():
+            if "default" in subschema:
+                instance.setdefault(property, subschema["default"])
+
+        for error in validate_properties(
+            validator, properties, instance, schema,
+        ):
+            yield error
+
+    return validators.extend(
+        validator_class, {"properties" : set_defaults},
+    )
+
+DefaultValidatingValidator = extend_with_default(Draft202012Validator)
+
+#schema for config variables. Will be used for both the config file and env vars
+schema = {
+    "type": "object",
+    "properties": {
+        "url": {
+            "type": "string",
+            "pattern": r"^(http|https):\/\/(([a-z0-9\-]+\.)+[a-z0-9\-]+|localhost)(:[0-9]+)?$",
+        },
+        "databasePath": {
+            "type": "string",
+            "default": user_data_dir(appname=programName, ensure_exists=True)
+        },
+        "loginSecurity": {
+            "type": "object",
+            "properties": {
+                "sessionSecretKey": {
+                    "type": [ "string", "null" ],
+                    "default": None
+                },
+                "sessionExpirationTimeMinutes": {
+                    "type": "integer",
+                    "minimum": 5,
+                    "default": 60
+                },
+                "allowedEmailDomains": {
+                    "type": [ "array" ],
+                    "items": {
+                        "type": "string",
+                        "pattern": r"^([a-z0-9\-]+\.)+[a-z0-9\-]+$"
+                    },
+                    "default": []
+                }
+            },
+            "additionalProperties": False,
+            "default": {} #required for defaults inside object to get applied
+        },
+        "smtpServer": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string",
+                    "pattern": r"^([a-z0-9\-]+\.)+[a-z0-9\-]+|localhost$",
+                },
+                "port": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 65535
+                },
+                "secure": {
+                    "type": "string",
+                    "pattern": r"^ssl|starttls$"
+                },
+                "senderEmail": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "required": [ "domain", "port", "secure", "senderEmail", "password" ],
+            "additionalProperties": False
+        },
+        "disableOptionValidation": {
+            "type": "boolean",
+            "default": False
+        }
+    },
+    "required": [ "url", "smtpServer" ],
+    "additionalProperties": False
 }
 
-def loadConfig(app):
-    #first set our app.config to the default values defined above
-    app.config.update(defaultConfig)
-
-    #next overwrite default values with values defined in config file
-    # search for config file
-    paths = [
-        Path("/etc/project-W/config.yml"),
-        Path.home().joinpath(".config", "project-W", "config.yml"),
-        Path("config.yml")
+def findConfigFile() -> Path:
+    searchDirs = [ 
+        user_config_path(appname=programName),
+        site_config_path(appname=programName),
+        Path(__file__).parent,
+        Path.cwd()
     ]
-    for path in paths:
-        if path.exists():
-            app.config.from_file(str(path), load=yaml.safe_load)
-            logger.info("loaded config from " + str(path))
-            break
-        else: logger.info(str(path) + " doesn't exist, couldn't load config file from there")
+    for dir in searchDirs:
+        configDir = dir / "config.yml"
+        if configDir.is_file(): return configDir
+    raise Exception("couldn't find a config.yml file in any search directory. Please add one")
 
-    #finally do the same thing for env variables (this means env vars have highest precedence)
-    #we only load env variables with prefix "PROJECT-W". This prefix will be removed when storing var in app.config
-    fileConfig: Dict = app.config.copy()
-    app.config.from_prefixed_env(prefix="PROJECT_W", loads=yaml.safe_load)
-    #the following makes sure that dicts inside our dict get updated and not overwritten. dicts inside dicts in our config are not supported
-    for name, value in fileConfig.items():
-        if isinstance(value, Dict): value.update(app.config[name])
-    for name, value in app.config.items():
-        if not isinstance(value, Dict): fileConfig[name] = value
-    app.config = fileConfig
+def loadConfig() -> Dict:
+    configPath = findConfigFile()
+    config = parse_config(configPath)
+
+    #print warning about option if it is set
+    if config.get("disableOptionValidation"):
+        logger.warning("'disableOptionValidation' has been enabled in your config. Only do this for development or testing purposes, never in production!")
+
+    #catch exception for validation with jsonscheme to implement disableOptionValidation
+    #and for better exception messages in terminal and log messages
+    try:
+        DefaultValidatingValidator(schema).validate(config)
+    except ValidationError as exc:
+        if not config.get("disableOptionValidation"):
+            msg = ""
+            if exc.validator == "required":
+                msg = "A required option is missing from your config.yml file:\n" + exc.message + "\nPlease make sure to define this option. Maybe you made a typo?"
+            elif exc.validator == "additionalProperties":
+                msg = "An undefined option has been found in your config.yml file:\n" + exc.message + "\nPlease remove this option from your config. Maybe you made a typo?"
+            else:
+                msg = "The option '" + exc.json_path + "' in your config.yml file has has an invalid value:\n" + exc.message + "\nPlease adjust this value. Maybe you made a typo?"
+            logger.exception(msg)
+            raise Exception(msg)
+        else:
+            logger.warning("Your config is invalid, some parts of this program will not work properly! Set 'disableOptionValidation' to false to learn more")
+
+    logger.info("successfully loaded config from: " + str(configPath))
+    return config

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -47,4 +47,6 @@ def loadConfig(app):
     #the following makes sure that dicts inside our dict get updated and not overwritten. dicts inside dicts in our config are not supported
     for name, value in fileConfig.items():
         if isinstance(value, Dict): value.update(app.config[name])
+    for name, value in app.config.items():
+        if not isinstance(value, Dict): fileConfig[name] = value
     app.config = fileConfig

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -1,0 +1,41 @@
+import yaml 
+import logging
+from pathlib import Path
+from flask import Flask
+
+# define default config options 
+# default options will be overwritten later if they are defined in config.yml or env vars
+defaultConfig = {
+    "DB_PATH": ".",
+    "JWT_SECRET_KEY": None,
+    "SMTP_SERVER": {
+        "domain": None,
+        "port": 587,
+        "secure": "tls",
+        "name": None,
+        "password": None,
+        "sender": None
+    }
+}
+
+def loadConfig(app: Flask, logger: logging.Logger):
+    #first set our app.config to the default values defined above
+    app.config.update(defaultConfig)
+
+    #next overwrite default values with values defined in config file
+    # search for config file
+    paths = [
+        Path("/etc/project-W/config.yml"),
+        Path.home().joinpath(".config", "project-W", "config.yml"),
+        Path("config.yml")
+    ]
+    for path in paths:
+        if path.exists():
+            app.config.from_file(str(path), load=yaml.safe_load)
+            logger.info("loaded config from " + str(path))
+            break
+        else: logger.info(str(path) + " doesn't exist, couldn't load config file from there")
+
+    #finally do the same thing for env variables (this means env vars have highest precedence)
+    #we only load env variables with prefix "PROJECT-W". This prefix will be removed when storing var in app.config
+    app.config.from_prefixed_env(prefix="PROJECT_W", loads=yaml.safe_load)

--- a/project_W/config.py
+++ b/project_W/config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 from jsonschema import Draft202012Validator, ValidationError, validators
 from platformdirs import user_data_dir, user_config_path, site_config_path
 from pyaml_env import parse_config
@@ -105,20 +105,22 @@ schema = {
     "additionalProperties": False
 }
 
-def findConfigFile() -> Path:
-    searchDirs = [ 
+def findConfigFile(additionalPaths: List[Path] = []) -> Path:
+    defaultSearchDirs = [ 
         user_config_path(appname=programName),
         site_config_path(appname=programName),
         Path(__file__).parent,
         Path.cwd()
     ]
+    searchDirs = additionalPaths + defaultSearchDirs
+
     for dir in searchDirs:
         configDir = dir / "config.yml"
         if configDir.is_file(): return configDir
     raise Exception("couldn't find a config.yml file in any search directory. Please add one")
 
-def loadConfig() -> Dict:
-    configPath = findConfigFile()
+def loadConfig(additionalPaths: List[Path] = []) -> Dict:
+    configPath = findConfigFile(additionalPaths)
     config = parse_config(configPath)
 
     #print warning about option if it is set

--- a/project_W/model.py
+++ b/project_W/model.py
@@ -75,12 +75,14 @@ def add_new_user(
 def activate_user(token: str) -> Tuple[str, int]:
     secret_key = flask.current_app.config["JWT_SECRET_KEY"]
     emails = decode_activation_token(token, secret_key)
-    old_email = emails["old_email"]
-    new_email = emails["new_email"]
 
     if emails is None:
         logger.info("  -> Invalid user activation token")
         return "Invalid or expired activation link", 400
+
+    old_email = emails["old_email"]
+    new_email = emails["new_email"]
+
     logger.info(f"  -> activation request for email '{new_email}'")
     user = db.session.execute(
         db.select(User).filter(User.email == old_email)

--- a/project_W/model.py
+++ b/project_W/model.py
@@ -5,8 +5,10 @@ from argon2 import PasswordHasher
 import argon2
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import exists
-
+from smtplib import SMTP, SMTP_SSL
+from email.message import EmailMessage
 from project_W.logger import get_logger
+import ssl
 
 db = SQLAlchemy()
 hasher = PasswordHasher()
@@ -24,6 +26,7 @@ class User(db.Model):
     user_key = db.Column(db.Text, nullable=False,
                          default=lambda: secrets.token_urlsafe(16))
     is_admin = db.Column(db.Boolean, nullable=False)
+    activated = db.Column(db.Boolean, nullable=False)
 
     def set_password_unchecked(self, new_password: str):
         self.invalidate_session_tokens()
@@ -56,7 +59,7 @@ class User(db.Model):
 
 
 def add_new_user(
-    email: str, password: str, is_admin: bool
+        email: str, password: str, is_admin: bool, smtpConfig: dict
 ) -> Tuple[str, int]:
     email_already_in_use = db.session.query(
         User.query.where(User.email == email).exists()).scalar()
@@ -97,3 +100,35 @@ def update_user_email(
     db.session.commit()
     logger.info(f" -> Updated email of user {user.email}")
     return "Successfully updated user email", 200
+
+def _send_email(
+        receiver: str, msg_body: str, msg_subject: str, smtpConfig: dict
+    ) -> bool:
+    msg = EmailMessage()
+    msg.set_content(msg_body)
+    msg["Subject"] = msg_subject
+    msg["From"] = smtpConfig["sender_email"]
+    msg["To"] = receiver
+    context = ssl.create_default_context()
+
+    try:
+        #default instance for unencrypted and starttls 
+        #ssl encrypts from beginning and requires a different instance
+        smtpInstance = SMTP(smtpConfig["domain"], smtpConfig["port"])
+        if smtpConfig["secure"] == "ssl":
+            smtpInstance = SMTP_SSL(smtpConfig["domain"], context=context)
+
+        with smtpInstance as server:
+            if smtpConfig["secure"] == "starttls": 
+                server.ehlo()
+                server.starttls(context=context)
+                server.ehlo()
+            server.login(smtpConfig["sender_email"], smtpConfig["password"])
+            server.send_message(msg)
+            logger.info(f" -> successfully sent email to {receiver}")
+
+        return True
+
+    except Exception as e:
+        logger.error(f" -> Error sending email to {receiver}: {e}")
+        return False

--- a/project_W/model.py
+++ b/project_W/model.py
@@ -107,15 +107,6 @@ def delete_user(
     return (f"Successfully deleted user with email {user.email}"), 200
 
 
-def update_user_email(
-    user: User, new_email: str
-) -> Tuple[str, int]:
-    user.set_email(new_email)
-    db.session.commit()
-    logger.info(f" -> Updated email of user {user.email}")
-    return "Successfully updated user email", 200
-
-
 def send_activation_email(old_email: str, new_email: str) -> bool:
     config = flask.current_app.config
     secret_key = config["JWT_SECRET_KEY"]

--- a/project_W/model.py
+++ b/project_W/model.py
@@ -96,7 +96,7 @@ def activate_user(token: str) -> Tuple[str, int]:
         logger.info(f"  -> User with email {old_email} already activated")
         return f"Account for {old_email} is already activated", 400
     user.activated = True
-    user.set_email = new_email #update email address (in case activation got issued for changed email address)
+    user.set_email(new_email) #update email address (in case activation got issued for changed email address)
     db.session.commit()
     return f"Account {new_email} activated", 200
 

--- a/project_W/utils.py
+++ b/project_W/utils.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 from itsdangerous.url_safe import URLSafeTimedSerializer
 from project_W.logger import get_logger
 from flask import json
@@ -23,7 +23,11 @@ def _decode_string_from_token(
 def encode_activation_token(oldEmail: str, newEmail: str, secret_key: str) -> str:
     return _encode_string_as_token(json.dumps({"old_email": oldEmail, "new_email": newEmail}), "activate", secret_key)
 
-def decode_activation_token(token: str, secret_key: str) -> dict:
+def decode_activation_token(token: str, secret_key: str) -> Dict|None:
     one_day_in_secs = 60 * 60 * 24
-    decodedData = json.loads(_decode_string_from_token(token, "activate", secret_key, one_day_in_secs))
-    return decodedData
+    decodedData = _decode_string_from_token(token, "activate", secret_key, one_day_in_secs)
+    if decodedData is None:
+        return None
+    else:
+        decodedDict = json.loads(decodedData)
+        return decodedDict

--- a/project_W/utils.py
+++ b/project_W/utils.py
@@ -20,6 +20,7 @@ def _decode_string_from_token(
         return None
     return decodedString
 
+
 def encode_activation_token(oldEmail: str, newEmail: str, secret_key: str) -> str:
     return _encode_string_as_token(json.dumps({"old_email": oldEmail, "new_email": newEmail}), "activate", secret_key)
 
@@ -31,3 +32,12 @@ def decode_activation_token(token: str, secret_key: str) -> Dict|None:
     else:
         decodedDict = json.loads(decodedData)
         return decodedDict
+
+def encode_password_reset_token(email: str, secret_key: str) -> str:
+    return _encode_string_as_token(email, "password-reset", secret_key)
+
+def decode_password_reset_token(token: str, secret_key: str) -> Optional[str]:
+    one_hour_in_secs = 60 * 60
+    return _decode_string_from_token(
+        token, "password-reset", secret_key, one_hour_in_secs
+    )

--- a/project_W/utils.py
+++ b/project_W/utils.py
@@ -24,7 +24,7 @@ def _decode_string_from_token(
 def encode_activation_token(oldEmail: str, newEmail: str, secret_key: str) -> str:
     return _encode_string_as_token(json.dumps({"old_email": oldEmail, "new_email": newEmail}), "activate", secret_key)
 
-def decode_activation_token(token: str, secret_key: str) -> Dict|None:
+def decode_activation_token(token: str, secret_key: str) -> Optional[Dict]:
     one_day_in_secs = 60 * 60 * 24
     decodedData = _decode_string_from_token(token, "activate", secret_key, one_day_in_secs)
     if decodedData is None:

--- a/project_W/utils.py
+++ b/project_W/utils.py
@@ -1,0 +1,29 @@
+from typing import Optional
+from itsdangerous.url_safe import URLSafeTimedSerializer
+from project_W.logger import get_logger
+from flask import json
+
+logger = get_logger("project-W")
+
+def _encode_string_as_token(string_to_encode: str, salt: str, secret_key: str) -> str:
+    ss = URLSafeTimedSerializer(secret_key, salt=salt)
+    return ss.dumps(string_to_encode)
+
+def _decode_string_from_token(
+    token: str, salt: str, secret_key: str, max_age_secs: int
+) -> Optional[str]:
+    ss = URLSafeTimedSerializer(secret_key, salt=salt)
+    try:
+        decodedString = ss.loads(token, max_age=max_age_secs)
+    except Exception as e:
+        logger.warning(f"Invalid or expired {salt} token: {e}")
+        return None
+    return decodedString
+
+def encode_activation_token(oldEmail: str, newEmail: str, secret_key: str) -> str:
+    return _encode_string_as_token(json.dumps({"old_email": oldEmail, "new_email": newEmail}), "activate", secret_key)
+
+def decode_activation_token(token: str, secret_key: str) -> dict:
+    one_day_in_secs = 60 * 60 * 24
+    decodedData = json.loads(_decode_string_from_token(token, "activate", secret_key, one_day_in_secs))
+    return decodedData

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,12 @@ dependencies = [
     "flask-jwt-extended",
     # SQL Flask plugin for database management
     "flask-sqlalchemy",
-    # PyYAML for parsing our yaml config file
-    "PyYAML"
+    # getting platform-independent directories for config and data (follows xdg standard on Linux)
+    "platformdirs",
+    # parsing config from yaml file and env vars
+    "pyaml_env",
+    #validating config files and filling out defaults
+    "jsonschema"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
 [project.optional-dependencies]
 tests = [
     "pytest",
+    "pytest-mock",
     "pytest-cov",
     "nbval",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "flask-jwt-extended",
     # SQL Flask plugin for database management
     "flask-sqlalchemy",
+    # PyYAML for parsing our yaml config file
+    "PyYAML"
 ]
 
 [project.optional-dependencies]

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-JWT_SECRET_KEY=$(cat JWT_SECRET_KEY) python -m flask --debug --app 'project_W:create_app()' run
+PROJECT_W_JWT_SECRET_KEY=$(cat JWT_SECRET_KEY) python -m flask --debug --app 'project_W:create_app()' run

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import smtplib
 import sys
 import flask
+import project_W
 import pytest
 from project_W import create_app
 from tests import get_auth_headers
@@ -10,32 +11,41 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 
 import flask_test_utils as ftu
 
-@pytest.fixture()
-def app(monkeypatch, tmp_path):
-    temp_db_path = str(tmp_path)
-    monkeypatch.setenv("PROJECT_W_JWT_SECRET_KEY", "abcdefghijklmnopqrstuvwxyz")
-    monkeypatch.setenv("PROJECT_W_DB_PATH", temp_db_path)
+#client fixture requires the following param: (str, str)
+#the strings will be the config values of 'allowedEmailDomains' and 'disableSignup' respectively and thus have to be written in yaml syntax
+@pytest.fixture(scope="function")
+def client(request, tmp_path):
+    #patch config.yml file
+    temp_config_path = str(tmp_path / "config.yml")
+    temp_db_dir = str(tmp_path)
+    configFile = open(temp_config_path, "w")
+    configFile.write(
+    f"url: 'https://example.com'\n"
+    f"databasePath: '{temp_db_dir}'\n"
+    f"loginSecurity:\n"
+    f"    sessionSecretKey: 'abcdefghijklmnopqrstuvwxyz'\n"
+    f"    allowedEmailDomains: {request.param[0]}\n" 
+    f"    disableSignup: {request.param[1]}\n"
+    f"smtpServer:\n"
+    f"    domain: 'smtp.example.com'\n"
+    f"    port: 587\n"
+    f"    secure: 'unencrypted'\n"
+    f"    senderEmail: 'alice@example.com'\n"
+    f"    username: 'alice@example.com'\n"
+    f"    password: 'thisisabadpassword'")
+    configFile.close()
 
-    monkeypatch.setattr(
-        smtplib.SMTP,
-        "__init__",
-        lambda self, host: print(f"Monkeypatched SMTP host: {host}", flush=True),
-    )
-    monkeypatch.setattr(
-        smtplib.SMTP,
-        "send_message",
-        lambda self, msg: flask.current_app.config.update(
-            TESTING_ONLY_LAST_SMTP_MESSAGE=msg
-        ),
-    )
-    app = create_app()
+    app = create_app(configFile.name)
     ftu.add_test_users(app)
-    yield app
 
+    yield app.test_client()
 
 @pytest.fixture()
-def client(app):
-    return app.test_client()
+def mockedSMTP(mocker):
+    mock_SMTP = mocker.MagicMock(name="project_W.model.SMTP")
+    mocker.patch("project_W.model.SMTP", new=mock_SMTP)
+
+    yield mock_SMTP
 
 def _auth_fixture(email, password):
     @pytest.fixture()
@@ -43,5 +53,5 @@ def _auth_fixture(email, password):
         return get_auth_headers(client, email, password)
     return auth
 
-user = _auth_fixture("user@test.com", "user")
-admin = _auth_fixture("admin@test.com", "admin")
+user = _auth_fixture("user@test.com", "userPassword1!")
+admin = _auth_fixture("admin@test.com", "adminPassword1!")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,5 @@
 import os
-import smtplib
 import sys
-import flask
-import project_W
 import pytest
 from project_W import create_app
 from tests import get_auth_headers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def client(request, tmp_path):
     temp_db_dir = str(tmp_path)
     configFile = open(temp_config_path, "w")
     configFile.write(
-    f"url: 'https://example.com'\n"
+    f"clientURL: 'https://example.com'\n"
     f"databasePath: '{temp_db_dir}'\n"
     f"loginSecurity:\n"
     f"    sessionSecretKey: 'abcdefghijklmnopqrstuvwxyz'\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,10 @@ import flask_test_utils as ftu
 
 @pytest.fixture()
 def app(monkeypatch, tmp_path):
-    monkeypatch.setenv("JWT_SECRET_KEY", "abcdefghijklmnopqrstuvwxyz")
+    temp_db_path = str(tmp_path)
+    monkeypatch.setenv("PROJECT_W_JWT_SECRET_KEY", "abcdefghijklmnopqrstuvwxyz")
+    monkeypatch.setenv("PROJECT_W_DB_PATH", temp_db_path)
+
     monkeypatch.setattr(
         smtplib.SMTP,
         "__init__",
@@ -25,8 +28,7 @@ def app(monkeypatch, tmp_path):
             TESTING_ONLY_LAST_SMTP_MESSAGE=msg
         ),
     )
-    temp_db_path = str(tmp_path)
-    app = create_app(temp_db_path)
+    app = create_app()
     ftu.add_test_users(app)
     yield app
 

--- a/tests/helpers/flask_test_utils.py
+++ b/tests/helpers/flask_test_utils.py
@@ -10,7 +10,7 @@ def add_test_users(app):
             db.session.add(
                 User(
                     email=email,
-                    password_hash=ph.hash(name),
+                    password_hash=ph.hash(name + "Password1!"),
                     is_admin=is_admin,
                     activated=True
                 )

--- a/tests/helpers/flask_test_utils.py
+++ b/tests/helpers/flask_test_utils.py
@@ -12,6 +12,7 @@ def add_test_users(app):
                     email=email,
                     password_hash=ph.hash(name),
                     is_admin=is_admin,
+                    activated=True
                 )
             )
         db.session.commit()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,7 +41,7 @@ def test_signup_invalid_invalidPassword(client: Client, password: str):
     res = client.post(
         "/api/signup", data={"email": "user2@test.com", "password": password})
     assert res.status_code == 400
-    assert res.json["message"] == "password invalid. The password needs to have at least one lower case letter, higher case letter, number, special character and at least 12 characters in total"
+    assert res.json["message"] == "password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"
 
 # user email is already in use
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
@@ -280,7 +280,7 @@ def test_resetPassword_invalid_invalidPassword(client: Client, mockedSMTP, passw
     res = client.post(
         "/api/resetPassword", query_string={"token": token}, data={"newPassword": password})
     assert res.status_code == 400
-    assert res.json["message"] == "password invalid. The password needs to have at least one lower case letter, higher case letter, number, special character and at least 12 characters in total"
+    assert res.json["message"] == "password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"
 
 #user deleted before password reset
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
@@ -519,7 +519,7 @@ def test_changeUserEmail_valid_nonAdmin(client: Client, mockedSMTP, user):
     res = client.post("/api/changeUserEmail", headers=user,
                       data={"password": "userPassword1!", "new_email": "user2@test.com"})
     assert res.status_code == 200
-    assert res.json["message"] == "Successfully requested email address change. Please confirm your new address be clicking on the link provided in the email we just sent you"
+    assert res.json["message"] == "Successfully requested email address change. Please confirm your new address by clicking on the link provided in the email we just sent you"
 
     #smtp stuff
     assert mockedSMTP.call_count == 1
@@ -537,7 +537,7 @@ def test_changeUserEmail_valid_admin(client: Client, mockedSMTP, admin):
     res = client.post("/api/changeUserEmail", headers=admin, data={
                       "password": "adminPassword1!", "new_email": "user2@test.com", "emailModify": "user@test.com"})
     assert res.status_code == 200
-    assert res.json["message"] == "Successfully requested email address change. Please confirm your new address be clicking on the link provided in the email we just sent you"
+    assert res.json["message"] == "Successfully requested email address change. Please confirm your new address by clicking on the link provided in the email we just sent you"
 
     #smtp stuff
     assert mockedSMTP.call_count == 1


### PR DESCRIPTION
This pull request got quiet large, I will try to separate stuff better in the future.
Anyway, this is whats new:
- loads yaml config into app.config at startup (defined in config.py). Includes:
  - ability to load variables from environmental variables instead (implemented in yaml parser, I used pyaml_env for this). What variables are loaded from env has to be defined in config
  - search at different paths following xdg standard (on Linux, code should be OS independent though): user config path -> system config path -> same path as config.py file -> working directory
  - ability to add custom path to load config from (will be added to path hierarchy above before 'user config path')
  - validation of config using jsonschema (includes required options and regex expressions for strings)
  - ability to disable 'required' check of jsonschema for development and testing purposes (maybe you don't want to define a smtp server in your config for development, and you don't care that signup and password reset won't work)
  - insertion of default values for non required options if they are not present in config file
  - nice error messages to help with typos etc.
- add email activation via smtp server
  - smtp server credentials are defined in yaml config
  - token generation is defined in utils.py
  - requires clientURL from yaml config to include a clickable link in the email. This link should not lead to an api url but to a nice UI from a client
  - user has to activate account over activate route for every new email
  - is done at signup and changeUserEmail
- add password reset
  - users can request password reset email (uses same smtp server, token and clientURL stuff as email activation)
  - users can reset their password to a new one over resetPassword route
- check new emails for validity
  - simple regex that checks if string looks like email
  - if 'allowedEmailDomains' in yaml config is not empty, then this regex will deny emails that are not from these domains
  - is done at signup and changeUserEmail
- check new passwords for validity
  - simple regex that checks if password withholds to certain standards
  - password has to include at least one: lower case letter, higher case letter, number, special character
  - password has to have at least 12 characters in total
  - is done at signup, changeUserPassword and passwordReset
- move databasePath, JWT Token Expiration and JWT secret key to yaml config
- ability to disable signup for new accounts over 'disableSignup' in yaml config
- lots of tests improvements
  - adjust client fixture in conftest.py for new yaml config
  - add indirect parametrize to client fixture to get different configs for different test cases with the same fixture
    - currently you can define values of 'allowedEmailDomains' and 'disableSignup'
    - parametrize can also be used to reuse code and write tests of same scheme more elegantly (e.g. invalidPassword, invalidEmail tests) 
  - add new fixture to mock smtp code
  - restructure tests
  - adjust all affected test for new behavior of functions
  - add tests for all new api functions

This required the following new dependencies (added to pyproject.toml):
- platformdirs (for getting OS independent and xdg conformant paths easily)
- pyaml_env (yaml parser with ability to also read variables from env vars)
- jsonschema (for schema validation of yaml config)
- (optional) tests: pytest-mock (a convenient wrapper for unittest.mock library of python to be used as a pytest fixture)


related todos (later):
- [ ] tests for model.py, utils.py, config.py
- [ ] documentation of api and yaml config usage


@MarkusEverling Since these are quite large changes, could you please review this PR? 