### PR TITLE
polishes and final additions to user management

### DIFF
--- a/project_W/app.py
+++ b/project_W/app.py
@@ -184,12 +184,15 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
         
         if not is_valid_email(newEmail): 
             return jsonify(msg=f"'{newEmail}' is not a valid email address", errorType="email", allowedEmailDomains=app.config["loginSecurity"]["allowedEmailDomains"]), 400
+        emailInUse: bool = db.session.query(
+            User.query.where(User.email == newEmail).exists()).scalar()
+        if emailInUse:
+            return jsonify(msg="E-Mail is already used by another account", errorType="email"), 400
 
         logger.info(f"user {thisUser.email} made request to modify user email of user {toModify.email} to {newEmail}")
 
         if send_activation_email(toModify.email, newEmail): 
             return jsonify(msg="Successfully requested email address change. Please confirm your new address by clicking on the link provided in the email we just sent you"), 200
-
         else:
             return jsonify(msg=f"Failed to send activation email to {newEmail}. Email address may not exist", errorType="email"), 400
 

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -196,6 +196,26 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
         else:
             return jsonify(msg=f"Failed to send activation email to {newEmail}. Email address may not exist", errorType="email"), 400
 
+    @app.get("/api/resendActivationEmail")
+    @jwt_required()
+    def resendActivationEmail():
+        user: User = current_user
+        if user.activated:
+            return jsonify(msg="This user is already activated", errorType="operation"), 400
+
+        if not send_activation_email(user.email, user.email):
+            return jsonify(msg=f"Failed to send password reset email to {user.email}.", errorType="email"), 400
+
+        return jsonify(msg=f"We have sent a new password reset email to {user.email}. Please check your emails"), 200
+
+    @app.get("/api/invalidateAllTokens")
+    @jwt_required()
+    def invalidateAllTokens():
+        user: User = current_user
+        user.invalidate_session_tokens()
+
+        return jsonify(msg="You have successfully been logged out accross all your devices"), 200
+
     with app.app_context():
         db.create_all()
 

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -208,7 +208,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
 
         return jsonify(msg=f"We have sent a new password reset email to {user.email}. Please check your emails"), 200
 
-    @app.get("/api/user/invalidateAllTokens")
+    @app.post("/api/user/invalidateAllTokens")
     @jwt_required()
     def invalidateAllTokens():
         user: User = current_user

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -65,7 +65,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
         # If the user doesn't exist then the token will fail anyways
         return JWT_SECRET_KEY
 
-    @app.post("/api/user/signup")
+    @app.post("/api/users/signup")
     def signup():
         if app.config["loginSecurity"]["disableSignup"]:
             return jsonify(msg="Signup of new accounts is disabled on this server", errorType="serverConfig"), 400
@@ -81,13 +81,13 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
 
         return add_new_user(email, password, False)
 
-    @app.post("/api/user/activate")
+    @app.post("/api/users/activate")
     def activate():
         if(token := request.form.get("token", type=str)):
             return activate_user(token)
         else: return jsonify(msg="You need a token to activate a users email", errorType="auth"), 400
 
-    @app.post("/api/user/login")
+    @app.post("/api/users/login")
     def login():
         email = request.form['email']
         password = request.form['password']
@@ -103,9 +103,9 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
         logger.info(" -> login successful, returning JWT token")
         return jsonify(msg="Login successful", access_token=create_access_token(user))
 
-    @app.get("/api/user/requestPasswordReset")
+    @app.get("/api/users/requestPasswordReset")
     def requestPasswordReset():
-        email = request.args.get("email", type=str)
+        email = request.args['email']
         logger.info(f"Password reset request for email {email}")
 
         user: Optional[User] = User.query.where(
@@ -118,7 +118,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
 
         return jsonify(msg=f"If an account with the address {email} exists, then we sent a password reset email to this address. Please check your emails"), 200
 
-    @app.post("/api/user/resetPassword")
+    @app.post("/api/users/resetPassword")
     def resetPassword():
         newPassword = request.form['newPassword']
 
@@ -129,7 +129,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
         else: return jsonify(msg="You need a token to reset a users password", errorType="auth"), 400
 
 
-    @app.get("/api/user/info")
+    @app.get("/api/users/info")
     @jwt_required()
     def userinfo():
         user: User = current_user
@@ -147,7 +147,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
             logger.info(f"Requested user info for {user.email}")
         return jsonify(email=user.email, is_admin=user.is_admin, activated=user.activated)
 
-    @app.post("/api/user/delete")
+    @app.post("/api/users/delete")
     @jwt_required()
     @confirmIdentity
     @emailModifyForAdmins
@@ -158,7 +158,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
 
         return delete_user(toModify)
 
-    @app.post("/api/user/changePassword")
+    @app.post("/api/users/changePassword")
     @jwt_required()
     @confirmIdentity
     @emailModifyForAdmins
@@ -174,7 +174,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
         toModify.set_password_unchecked(newPassword)
         return jsonify(msg="Successfully updated user password"), 200
 
-    @app.post("/api/user/changeEmail")
+    @app.post("/api/users/changeEmail")
     @jwt_required()
     @confirmIdentity
     @emailModifyForAdmins
@@ -196,7 +196,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
         else:
             return jsonify(msg=f"Failed to send activation email to {newEmail}. Email address may not exist", errorType="email"), 400
 
-    @app.get("/api/user/resendActivationEmail")
+    @app.get("/api/users/resendActivationEmail")
     @jwt_required()
     def resendActivationEmail():
         user: User = current_user
@@ -208,7 +208,7 @@ def create_app(customConfigPath: Optional[str] = None) -> Flask:
 
         return jsonify(msg=f"We have sent a new password reset email to {user.email}. Please check your emails"), 200
 
-    @app.post("/api/user/invalidateAllTokens")
+    @app.post("/api/users/invalidateAllTokens")
     @jwt_required()
     def invalidateAllTokens():
         user: User = current_user

--- a/project_W/app.py
+++ b/project_W/app.py
@@ -4,6 +4,7 @@ from typing import Optional
 from pathlib import Path
 from flask import Flask, jsonify, request
 from flask_jwt_extended import JWTManager, create_access_token, current_user, jwt_required
+from flask_cors import CORS
 from .logger import get_logger
 from .model import User, add_new_user, delete_user, db, activate_user, send_activation_email, send_password_reset_email, reset_user_password, is_valid_email, is_valid_password, confirmIdentity, emailModifyForAdmins
 from .config import loadConfig
@@ -11,6 +12,7 @@ from .config import loadConfig
 def create_app(customConfigPath: Optional[str] = None) -> Flask:
     logger = get_logger("project-W")
     app = Flask("project-W")
+    CORS(app)
 
     #load config from additionalPaths (if not None) + defaultSearchDirs
     if customConfigPath is None:

--- a/project_W/model.py
+++ b/project_W/model.py
@@ -30,17 +30,20 @@ class User(db.Model):
     activated = db.Column(db.Boolean, nullable=False)
 
     def set_password_unchecked(self, new_password: str):
-        self.invalidate_session_tokens()
-        self.password_hash = hasher.hash(new_password)
-        db.session.commit()
-        logger.info(f" -> Updated password of user {self.email}")
+        new_password_hash = hasher.hash(new_password)
+        if new_password_hash != self.password_hash:
+            self.invalidate_session_tokens()
+            self.password_hash = new_password_hash
+            db.session.commit()
+            logger.info(f" -> Updated password of user {self.email}")
 
     def set_email(self, new_email: str):
-        self.invalidate_session_tokens()
-        old_email = self.email
-        self.email = new_email
-        db.session.commit()
-        logger.info(f" -> Updated email from {old_email} to {self.email}")
+        if new_email != self.email:
+            self.invalidate_session_tokens()
+            old_email = self.email
+            self.email = new_email
+            db.session.commit()
+            logger.info(f" -> Updated email from {old_email} to {self.email}")
 
     def check_password(self, password: str) -> bool:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "flask-jwt-extended",
     # SQL Flask plugin for database management
     "flask-sqlalchemy",
+    # for setting header for cors support globally
+    "flask-cors",
     # getting platform-independent directories for config and data (follows xdg standard on Linux)
     "platformdirs",
     # parsing config from yaml file and env vars

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,6 @@ def get_auth_headers(
     client, email: str = "user@test.com", password: str = "user"
 ) -> Dict[str, str]:
     response = client.post(
-        "/api/user/login", data={"email": email, "password": password})
+        "/api/users/login", data={"email": email, "password": password})
     token = response.json["access_token"]
     return {"Authorization": f"Bearer {token}"}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,6 @@ def get_auth_headers(
     client, email: str = "user@test.com", password: str = "user"
 ) -> Dict[str, str]:
     response = client.post(
-        "/api/login", data={"email": email, "password": password})
+        "/api/user/login", data={"email": email, "password": password})
     token = response.json["access_token"]
     return {"Authorization": f"Bearer {token}"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -554,6 +554,18 @@ def test_changeUserEmail_invalid_invalidEmail2(client: Client, email: str, user)
     assert res.json["allowedEmailDomains"] == [ 'test.com' ]
     assert res.json["errorType"] == "email"
 
+# provided 'email's domain is not in 'allowedEmailDomains'
+@pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
+def test_changeUserEmail_invalid_emailAlreadyInUse(client: Client, mockedSMTP, user):
+    res = client.post("/api/changeUserEmail", headers=user,
+                      data={"password": "userPassword1!", "newEmail": "admin@test.com"})
+    assert res.status_code == 400 
+    assert res.json["msg"] == "E-Mail is already used by another account"
+    assert res.json["errorType"] == "email"
+
+    #smtp stuff: it didn't send an email
+    assert mockedSMTP.call_count == 0
+
 # email couldn't be sent
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_changeUserEmail_invalid_brokenSMTP(client: Client, mockedSMTP, user):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -396,16 +396,16 @@ def test_deleteUser_invalid_wrongPassword(client: Client, user):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_deleteUser_invalid_noPermissions(client: Client, user):
     res = client.post("/api/deleteUser", headers=user,
-                      data={"password": "userPassword1!", "emailDelete": "admin@test.com"})
+                      data={"password": "userPassword1!", "emailModify": "admin@test.com"})
     assert res.status_code == 403
-    assert res.json["msg"] == "You don't have permission to delete other users"
+    assert res.json["msg"] == "You don't have permission to modify other users"
     assert res.json["errorType"] == "permission"
 
 # admin user who tries to delete other user, but email is invalid
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_deleteUser_invalid_wrongEmail(client: Client, admin):
     res = client.post("/api/deleteUser", headers=admin,
-                      data={"password": "adminPassword1!", "emailDelete": "abc@xyz.com"})
+                      data={"password": "adminPassword1!", "emailModify": "abc@xyz.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "No user exists with that email"
     assert res.json["errorType"] == "notInDatabase"
@@ -423,7 +423,7 @@ def test_deleteUser_valid_nonAdmins(client: Client, user):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_deleteUser_valid_Admins(client: Client, admin):
     res = client.post("/api/deleteUser", headers=admin,
-                      data={"password": "adminPassword1!", "emailDelete": "user@test.com"})
+                      data={"password": "adminPassword1!", "emailModify": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully deleted user with email user@test.com"
 
@@ -479,7 +479,7 @@ def test_changeUserPassword_valid_normal(client: Client, user):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changeUserPassword_valid_admin(client: Client, admin):
     res = client.post("/api/changeUserPassword", headers=admin, data={
-                      "password": "adminPassword1!", "newPassword": "admin2Password!", "emailDelete": "user@test.com"})
+                      "password": "adminPassword1!", "newPassword": "admin2Password!", "emailModify": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully updated user password"
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -638,3 +638,11 @@ def test_changeUserEmail_revokes_session(client: Client, mockedSMTP, user):
     # the request should fail because the jwt token has been revoked.
     # by changing the user password
     assert 400 <= res.status_code < 500
+
+@pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
+def test_corsSupport(client: Client, user):
+    res = client.get("/api/userinfo", headers=user)
+    assert res.status_code == 200
+
+    assert res.headers.get("Access-Control-Allow-Origin") == "*"
+

--- a/tests/test_user-management.py
+++ b/tests/test_user-management.py
@@ -688,7 +688,7 @@ def test_resendActivationEmail_valid(client: Client, mockedSMTP, user):
 # successful call and login tokesn invalidated
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_invalidateAllTokens_valid(client: Client, user):
-    res = client.get("/api/user/invalidateAllTokens", headers=user)
+    res = client.post("/api/user/invalidateAllTokens", headers=user)
     assert res.status_code == 200
     assert res.json["msg"] == "You have successfully been logged out accross all your devices"
 

--- a/tests/test_user-management.py
+++ b/tests/test_user-management.py
@@ -6,7 +6,7 @@ from tests import get_auth_headers
 @pytest.mark.parametrize("client", [("[]", "true"), ("[ 'test.com' ]", "true"), ("[ 'test.com', 'sub.test.com' ]", "true")], indirect=True)
 def test_signup_invalid_disabledSignup(client: Client):
     res = client.post(
-        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/users/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Signup of new accounts is disabled on this server"
     assert res.json["errorType"] == "serverConfig"
@@ -14,7 +14,7 @@ def test_signup_invalid_disabledSignup(client: Client):
 # missing form data
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_signup_invalid_missingFormData(client: Client):
-    res = client.post("/api/user/signup")
+    res = client.post("/api/users/signup")
     # leads to a flask error
     assert 400 <= res.status_code < 500
 
@@ -22,7 +22,7 @@ def test_signup_invalid_missingFormData(client: Client):
 @pytest.mark.parametrize("client, email", [(("[]", "false"), "abcdefg"), (("[]", "false"), "user2"), (("[]", "false"), "user2@test"), (("[]", "false"), "user2@test."), (("[]", "false"), "@test.com")], indirect=["client"])
 def test_signup_invalid_invalidEmail1(client: Client, email: str):
     res = client.post(
-        "/api/user/signup", data={"email": email, "password": "user2Password1!"})
+        "/api/users/signup", data={"email": email, "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == f"'{email}' is not a valid email address"
     assert res.json["allowedEmailDomains"] == []
@@ -32,7 +32,7 @@ def test_signup_invalid_invalidEmail1(client: Client, email: str):
 @pytest.mark.parametrize("client, email", [(("[ 'test.com' ]", "false"), "user2@test.de"), (("[ 'test.com' ]", "false"), "user2@sub.test.com")], indirect=["client"])
 def test_signup_invalid_invalidEmail2(client: Client, email: str):
     res = client.post(
-        "/api/user/signup", data={"email": email, "password": "user2Password1!"})
+        "/api/users/signup", data={"email": email, "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == f"'{email}' is not a valid email address"
     assert res.json["allowedEmailDomains"] == [ 'test.com' ]
@@ -42,7 +42,7 @@ def test_signup_invalid_invalidEmail2(client: Client, email: str):
 @pytest.mark.parametrize("client, password", [(("[]", "false"), "user2"), (("[]", "false"), "tooShort58!"), (("[]", "false"), "thispasswordhasnouppercasechars390!"), (("[]", "false"), "THISPASSWORDHASNOLOWERCASE$%=56"), (("[]", "false"), "ThisPasswordHasNoNumbers!"), (("[]", "false"), "ThisPasswordHasNoSymbols123"), (("[]", "false"), "thispasswordhasnouppercasechars390!")], indirect=["client"])
 def test_signup_invalid_invalidPassword(client: Client, password: str):
     res = client.post(
-        "/api/user/signup", data={"email": "user2@test.com", "password": password})
+        "/api/users/signup", data={"email": "user2@test.com", "password": password})
     assert res.status_code == 400
     assert res.json["msg"] == "Password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"
     assert res.json["errorType"] == "password"
@@ -51,7 +51,7 @@ def test_signup_invalid_invalidPassword(client: Client, password: str):
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_signup_invalid_emailAlreadyInUse(client: Client):
     res = client.post(
-        "/api/user/signup", data={"email": "user@test.com", "password": "user2Password1!"})
+        "/api/users/signup", data={"email": "user@test.com", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "E-Mail is already used by another account"
     assert res.json["errorType"] == "email"
@@ -62,7 +62,7 @@ def test_signup_invalid_brokenSMTP(client: Client, mockedSMTP):
     mockedSMTP.side_effect = smtplib.SMTPException
 
     res = client.post(
-        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/users/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Failed to send activation email to user2@test.com. Email address may not exist"
     assert res.json["errorType"] == "email"
@@ -74,7 +74,7 @@ def test_signup_invalid_brokenSMTP(client: Client, mockedSMTP):
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_signup_valid(client: Client, mockedSMTP):
     res = client.post(
-        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/users/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successful signup for user2@test.com. Please activate your account be clicking on the link provided in the email we just sent you"
 
@@ -94,7 +94,7 @@ def test_signup_valid(client: Client, mockedSMTP):
 #no token in query string
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_invalid_noToken(client: Client):
-    res = client.post("/api/user/activate")
+    res = client.post("/api/users/activate")
     assert res.status_code == 400
     assert res.json["msg"] == "You need a token to activate a users email"
     assert res.json["errorType"] == "auth"
@@ -103,7 +103,7 @@ def test_activate_invalid_noToken(client: Client):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_invalid_invalidToken(client: Client):
     #hint: tokens are 127 characters long
-    res = client.post("/api/user/activate", data={"token": "safjdDkdf8239hf839fdFsdfas.FDSf239dHF001fdhFDFfuisagu.6asdjgKOPFDdfsFDDgufg898989898dU89789fFDDGudufFD123449FGDjhgdfhgfua5438FD"})
+    res = client.post("/api/users/activate", data={"token": "safjdDkdf8239hf839fdFsdfas.FDSf239dHF001fdhFDFfuisagu.6asdjgKOPFDdfsFDDgufg898989898dU89789fFDDGudufFD123449FGDjhgdfhgfua5438FD"})
     assert res.status_code == 400
     assert res.json["msg"] == "Invalid or expired activation link"
     assert res.json["errorType"] == "auth"
@@ -112,7 +112,7 @@ def test_activate_invalid_invalidToken(client: Client):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_invalid_userDeleted(client: Client, mockedSMTP):
     res = client.post(
-        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/users/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
@@ -120,11 +120,11 @@ def test_activate_invalid_userDeleted(client: Client, mockedSMTP):
     token = tokenLine.partition("token=")[2]
 
     user2 = get_auth_headers(client, "user2@test.com", "user2Password1!")
-    res = client.post("/api/user/delete", headers=user2,
+    res = client.post("/api/users/delete", headers=user2,
                       data={"password": "user2Password1!"})
     assert res.status_code == 200
 
-    res = client.post("/api/user/activate", data={"token": token})
+    res = client.post("/api/users/activate", data={"token": token})
     assert res.status_code == 400
     assert res.json["msg"] == "No user with email user2@test.com exists"
     assert res.json["errorType"] == "notInDatabase"
@@ -133,16 +133,16 @@ def test_activate_invalid_userDeleted(client: Client, mockedSMTP):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_invalid_userAlreadyActivated(client: Client, mockedSMTP):
     res = client.post(
-        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/users/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.post("/api/user/activate", data={"token": token})
+    res = client.post("/api/users/activate", data={"token": token})
     assert res.status_code == 200
 
-    res = client.post("/api/user/activate", data={"token": token})
+    res = client.post("/api/users/activate", data={"token": token})
     assert res.status_code == 400
     assert res.json["msg"] == "Account for user2@test.com is already activated"
     assert res.json["errorType"] == "operation"
@@ -152,21 +152,21 @@ def test_activate_invalid_userAlreadyActivated(client: Client, mockedSMTP):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_valid_signup(client: Client, mockedSMTP):
     res = client.post(
-        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/users/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.post("/api/user/activate", data={"token": token})
+    res = client.post("/api/users/activate", data={"token": token})
     assert res.status_code == 200
     assert res.json["msg"] == "Account user2@test.com activated"
 
 #valid after email address change
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_valid_emailChange(client: Client, mockedSMTP, user):
-    res = client.post("/api/user/changeEmail", headers=user,
+    res = client.post("/api/users/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user2@test.com"})
     assert res.status_code == 200
 
@@ -174,7 +174,7 @@ def test_activate_valid_emailChange(client: Client, mockedSMTP, user):
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.post("/api/user/activate", data={"token": token})
+    res = client.post("/api/users/activate", data={"token": token})
     assert res.status_code == 200
     assert res.json["msg"] == "Account user2@test.com activated"
 
@@ -184,7 +184,7 @@ def test_activate_valid_tokenStaysValid(client: Client, mockedSMTP):
     email: str = "user2@test.com"
     password: str = "user2Password1!"
     signupRes = client.post(
-        "/api/user/signup", data={"email": email, "password": password})
+        "/api/users/signup", data={"email": email, "password": password})
     assert signupRes.status_code == 200
 
     user2 = get_auth_headers(client, email, password)
@@ -192,10 +192,10 @@ def test_activate_valid_tokenStaysValid(client: Client, mockedSMTP):
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
-    activateRes = client.post("/api/user/activate", data={"token": token})
+    activateRes = client.post("/api/users/activate", data={"token": token})
     assert activateRes.status_code == 200
 
-    infoRes = client.get("/api/user/info", headers=user2)
+    infoRes = client.get("/api/users/info", headers=user2)
     assert infoRes.status_code == 200
 
 
@@ -204,13 +204,13 @@ def test_activate_valid_tokenStaysValid(client: Client, mockedSMTP):
 # missing form data
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_login_invalid_missingFormData(client: Client):
-    res = client.post("/api/user/login")
+    res = client.post("/api/users/login")
     assert 400 <= res.status_code < 500
 
 # unknown email
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_login_invalid_unknownEmail(client: Client):
-    res = client.post("/api/user/login", data={"email": "", "password": "user2Password1!"})
+    res = client.post("/api/users/login", data={"email": "", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Incorrect credentials provided"
     assert res.json["errorType"] == "auth"
@@ -219,7 +219,7 @@ def test_login_invalid_unknownEmail(client: Client):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_login_invalid_wrongPassword(client: Client):
     res = client.post(
-        "/api/user/login", data={"email": "user@test.com", "password": "user2Password1!"})
+        "/api/users/login", data={"email": "user@test.com", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Incorrect credentials provided"
     assert res.json["errorType"] == "auth"
@@ -230,7 +230,7 @@ def test_login_valid(client: Client):
     email = "user@test.com"
     password = "userPassword1!"
     response = client.post(
-        "/api/user/login", data={"email": email, "password": password})
+        "/api/users/login", data={"email": email, "password": password})
     assert response.status_code == 200
     assert response.json["msg"] == "Login successful"
     assert "access_token" in response.json
@@ -242,7 +242,7 @@ def test_login_valid(client: Client):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_requestPasswordReset_invalid_invalidEmail(client: Client, mockedSMTP):
     res = client.get(
-        "/api/user/requestPasswordReset", query_string={"email": "user2@test.com"})
+        "/api/users/requestPasswordReset", query_string={"email": "user2@test.com"})
     #you shouldn't be able to see from the client side if an entered email belongs to a user or not
     assert res.status_code == 200
     assert res.json["msg"] == f"If an account with the address user2@test.com exists, then we sent a password reset email to this address. Please check your emails"
@@ -256,7 +256,7 @@ def test_requestPasswordReset_invalid_brokenSMTP(client: Client, mockedSMTP):
     mockedSMTP.side_effect = smtplib.SMTPException
 
     res = client.get(
-        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
+        "/api/users/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "Failed to send password reset email to user@test.com."
     assert res.json["errorType"] == "email"
@@ -267,7 +267,7 @@ def test_requestPasswordReset_invalid_brokenSMTP(client: Client, mockedSMTP):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_requestPasswordReset_valid(client: Client, mockedSMTP):
     res = client.get(
-        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
+        "/api/users/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == f"If an account with the address user@test.com exists, then we sent a password reset email to this address. Please check your emails"
 
@@ -288,7 +288,7 @@ def test_requestPasswordReset_valid(client: Client, mockedSMTP):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resetPassword_invalid_noToken(client: Client):
     res = client.post(
-        "/api/user/resetPassword", data={"newPassword": "user2Password1!"})
+        "/api/users/resetPassword", data={"newPassword": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "You need a token to reset a users password"
     assert res.json["errorType"] == "auth"
@@ -298,7 +298,7 @@ def test_resetPassword_invalid_noToken(client: Client):
 def test_resetPassword_invalid_invalidToken(client: Client):
     #hint: tokens are 127 characters long
     res = client.post(
-        "/api/user/resetPassword", data={"token": "safjdDkdf8239hf839fdFsdfas.FDSf239dHF001fdhFDFfuisagu.6asdjgKOPFDdfsFDDgufg898989898dU89789fFDDGudufFD123449FGDjhgdfhgfua5438FD", "newPassword": "user2Password1!"})
+        "/api/users/resetPassword", data={"token": "safjdDkdf8239hf839fdFsdfas.FDSf239dHF001fdhFDFfuisagu.6asdjgKOPFDdfsFDDgufg898989898dU89789fFDDGudufFD123449FGDjhgdfhgfua5438FD", "newPassword": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Invalid or expired password reset link"
     assert res.json["errorType"] == "auth"
@@ -307,7 +307,7 @@ def test_resetPassword_invalid_invalidToken(client: Client):
 @pytest.mark.parametrize("client, password", [(("[]", "false"), "user2"), (("[]", "false"), "tooShort58!"), (("[]", "false"), "thispasswordhasnouppercasechars390!"), (("[]", "false"), "THISPASSWORDHASNOLOWERCASE$%=56"), (("[]", "false"), "ThisPasswordHasNoNumbers!"), (("[]", "false"), "ThisPasswordHasNoSymbols123"), (("[]", "false"), "thispasswordhasnouppercasechars390!")], indirect=["client"])
 def test_resetPassword_invalid_invalidPassword(client: Client, mockedSMTP, password: str):
     res = client.get(
-        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
+        "/api/users/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
@@ -315,7 +315,7 @@ def test_resetPassword_invalid_invalidPassword(client: Client, mockedSMTP, passw
     token = tokenLine.partition("token=")[2]
 
     res = client.post(
-        "/api/user/resetPassword", query_string={}, data={"token": token, "newPassword": password})
+        "/api/users/resetPassword", query_string={}, data={"token": token, "newPassword": password})
     assert res.status_code == 400
     assert res.json["msg"] == "Password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"
     assert res.json["errorType"] == "password"
@@ -324,19 +324,19 @@ def test_resetPassword_invalid_invalidPassword(client: Client, mockedSMTP, passw
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resetPassword_invalid_userDeleted(client: Client, mockedSMTP, user):
     res = client.get(
-        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
+        "/api/users/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.post("/api/user/delete", headers=user,
+    res = client.post("/api/users/delete", headers=user,
                       data={"password": "userPassword1!"})
     assert res.status_code == 200
 
     res = client.post(
-        "/api/user/resetPassword", data={"token": token, "newPassword": "user2Password1!"})
+        "/api/users/resetPassword", data={"token": token, "newPassword": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Unknown email address user@test.com"
     assert res.json["errorType"] == "notInDatabase"
@@ -344,7 +344,7 @@ def test_resetPassword_invalid_userDeleted(client: Client, mockedSMTP, user):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resetPassword_valid(client: Client, mockedSMTP):
     res = client.get(
-        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
+        "/api/users/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
@@ -352,7 +352,7 @@ def test_resetPassword_valid(client: Client, mockedSMTP):
     token = tokenLine.partition("token=")[2]
 
     res = client.post(
-        "/api/user/resetPassword", data={"token": token, "newPassword": "user2Password1!"})
+        "/api/users/resetPassword", data={"token": token, "newPassword": "user2Password1!"})
     assert res.status_code == 200
     assert res.json["msg"] == "password changed successfully"
 
@@ -362,7 +362,7 @@ def test_resetPassword_valid(client: Client, mockedSMTP):
 # non-admins can't access other users' infos
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_info_invalid_noPermissions(client: Client, user):
-    res = client.get("/api/user/info", headers=user,
+    res = client.get("/api/users/info", headers=user,
                      query_string={"email": "admin@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "You don't have permission to view other accounts' user info"
@@ -371,7 +371,7 @@ def test_info_invalid_noPermissions(client: Client, user):
 # can't access non-existent user info
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_info_invalid_wrongEmail(client: Client, admin):
-    res = client.get("/api/user/info", headers=admin,
+    res = client.get("/api/users/info", headers=admin,
                      query_string={"email": "fake@test.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "No user exists with that email"
@@ -381,7 +381,7 @@ def test_info_invalid_wrongEmail(client: Client, admin):
 # non-admins can access their own user info
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_info_valid_nonAdmins(client: Client, user):
-    res = client.get("/api/user/info", headers=user)
+    res = client.get("/api/users/info", headers=user)
     assert res.status_code == 200
     assert res.json["email"] == "user@test.com"
     assert res.json["is_admin"] == False
@@ -389,13 +389,13 @@ def test_info_valid_nonAdmins(client: Client, user):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_info_valid_admins(client: Client, admin):
     # admins can also access their own user info
-    res = client.get("/api/user/info", headers=admin)
+    res = client.get("/api/users/info", headers=admin)
     assert res.status_code == 200
     assert res.json["email"] == "admin@test.com"
     assert res.json["is_admin"] == True
 
     # admins can access other users' info
-    res = client.get("/api/user/info", headers=admin,
+    res = client.get("/api/users/info", headers=admin,
                      query_string={"email": "user@test.com"})
     assert res.status_code == 200
     assert res.json["email"] == "user@test.com"
@@ -407,7 +407,7 @@ def test_info_valid_admins(client: Client, admin):
 # wrong password
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_delete_invalid_wrongPassword(client: Client, user):
-    res = client.post("/api/user/delete", headers=user,
+    res = client.post("/api/users/delete", headers=user,
                       data={"password": "user2Password1!"})
     assert res.status_code == 403
     assert res.json["msg"] == "Incorrect password provided"
@@ -416,7 +416,7 @@ def test_delete_invalid_wrongPassword(client: Client, user):
 # normal user who tries to delete other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_delete_invalid_noPermissions(client: Client, user):
-    res = client.post("/api/user/delete", headers=user,
+    res = client.post("/api/users/delete", headers=user,
                       data={"password": "userPassword1!", "emailModify": "admin@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "You don't have permission to modify other users"
@@ -425,7 +425,7 @@ def test_delete_invalid_noPermissions(client: Client, user):
 # admin user who tries to delete other user, but email is invalid
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_delete_invalid_wrongEmail(client: Client, admin):
-    res = client.post("/api/user/delete", headers=admin,
+    res = client.post("/api/users/delete", headers=admin,
                       data={"password": "adminPassword1!", "emailModify": "abc@xyz.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "No user exists with that email"
@@ -435,7 +435,7 @@ def test_delete_invalid_wrongEmail(client: Client, admin):
 # normal user deletes themselves
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_delete_valid_nonAdmins(client: Client, user):
-    res = client.post("/api/user/delete", headers=user,
+    res = client.post("/api/users/delete", headers=user,
                       data={"password": "userPassword1!"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully deleted user with email user@test.com"
@@ -443,7 +443,7 @@ def test_delete_valid_nonAdmins(client: Client, user):
 # admin user deletes other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_delete_valid_Admins(client: Client, admin):
-    res = client.post("/api/user/delete", headers=admin,
+    res = client.post("/api/users/delete", headers=admin,
                       data={"password": "adminPassword1!", "emailModify": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully deleted user with email user@test.com"
@@ -454,7 +454,7 @@ def test_delete_valid_Admins(client: Client, admin):
 # wrong password
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changePassword_invalid_wrongPassword(client: Client, user):
-    res = client.post("/api/user/changePassword", headers=user,
+    res = client.post("/api/users/changePassword", headers=user,
                       data={"password": "userPassword2!", "newPassword": "user2Password1!"})
     assert res.status_code == 403
     assert res.json["msg"] == "Incorrect password provided"
@@ -463,7 +463,7 @@ def test_changePassword_invalid_wrongPassword(client: Client, user):
 # normal user who tries to modify other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changePassword_invalid_noPermissions(client: Client, user):
-    res = client.post("/api/user/changePassword", headers=user, data={
+    res = client.post("/api/users/changePassword", headers=user, data={
                       "password": "userPassword1!", "newPassword": "user2Password1!", "emailModify": "admin@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "You don't have permission to modify other users"
@@ -472,7 +472,7 @@ def test_changePassword_invalid_noPermissions(client: Client, user):
 # admin user who tries to modify other user, but email is invalid
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changePassword_invalid_wrongEmail(client: Client, admin):
-    res = client.post("/api/user/changePassword", headers=admin, data={
+    res = client.post("/api/users/changePassword", headers=admin, data={
                       "password": "adminPassword1!", "newPassword": "adminPassword2!", "emailModify": "abc@xyz.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "No user exists with that email"
@@ -481,7 +481,7 @@ def test_changePassword_invalid_wrongEmail(client: Client, admin):
 #newPassword does not meet criteria
 @pytest.mark.parametrize("client, password", [(("[]", "false"), "user2"), (("[]", "false"), "tooShort58!"), (("[]", "false"), "thispasswordhasnouppercasechars390!"), (("[]", "false"), "THISPASSWORDHASNOLOWERCASE$%=56"), (("[]", "false"), "ThisPasswordHasNoNumbers!"), (("[]", "false"), "ThisPasswordHasNoSymbols123"), (("[]", "false"), "thispasswordhasnouppercasechars390!")], indirect=["client"])
 def test_changePassword_invalid_invalidPassword(client: Client, password: str, user):
-    res = client.post("/api/user/changePassword", headers=user,
+    res = client.post("/api/users/changePassword", headers=user,
                       data={"password": "userPassword1!", "newPassword": password})
     assert res.status_code == 400
     assert res.json["msg"] == "Password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"
@@ -491,7 +491,7 @@ def test_changePassword_invalid_invalidPassword(client: Client, password: str, u
 # normal user modifies themselves
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changePassword_valid_normal(client: Client, user):
-    res = client.post("/api/user/changePassword", headers=user,
+    res = client.post("/api/users/changePassword", headers=user,
                       data={"password": "userPassword1!", "newPassword": "user2Password1!"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully updated user password"
@@ -499,7 +499,7 @@ def test_changePassword_valid_normal(client: Client, user):
 # admin user deletes other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changePassword_valid_admin(client: Client, admin):
-    res = client.post("/api/user/changePassword", headers=admin, data={
+    res = client.post("/api/users/changePassword", headers=admin, data={
                       "password": "adminPassword1!", "newPassword": "admin2Password!", "emailModify": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully updated user password"
@@ -510,7 +510,7 @@ def test_changePassword_valid_admin(client: Client, admin):
 # wrong password
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changeEmail_invalid_wrongPassword(client: Client, user):
-    res = client.post("/api/user/changeEmail", headers=user,
+    res = client.post("/api/users/changeEmail", headers=user,
                       data={"password": "userPassword2!", "newEmail": "user2@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "Incorrect password provided"
@@ -519,7 +519,7 @@ def test_changeEmail_invalid_wrongPassword(client: Client, user):
 # normal user who tries to modify other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changeEmail_invalid_noPermissions(client: Client, user):
-    res = client.post("/api/user/changeEmail", headers=user, data={
+    res = client.post("/api/users/changeEmail", headers=user, data={
                       "password": "userPassword1!", "newEmail": "user2@test.com", "emailModify": "admin@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "You don't have permission to modify other users"
@@ -528,7 +528,7 @@ def test_changeEmail_invalid_noPermissions(client: Client, user):
 # admin user who tries to modify other user, but email is invalid
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changeEmail_invalid_wrongEmail(client: Client, admin):
-    res = client.post("/api/user/changeEmail", headers=admin, data={
+    res = client.post("/api/users/changeEmail", headers=admin, data={
                       "password": "adminPassword1!", "newEmail": "abc2@xyz.com", "emailModify": "abc@xyz.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "No user exists with that email"
@@ -537,7 +537,7 @@ def test_changeEmail_invalid_wrongEmail(client: Client, admin):
 # provided 'email' is not an email address
 @pytest.mark.parametrize("client, email", [(("[]", "false"), "abcdefg"), (("[]", "false"), "user2"), (("[]", "false"), "user2@test"), (("[]", "false"), "user2@test."), (("[]", "false"), "@test.com")], indirect=["client"])
 def test_changeEmail_invalid_invalidEmail1(client: Client, email: str, user):
-    res = client.post("/api/user/changeEmail", headers=user,
+    res = client.post("/api/users/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": email})
     assert res.status_code == 400
     assert res.json["msg"] == f"'{email}' is not a valid email address"
@@ -547,7 +547,7 @@ def test_changeEmail_invalid_invalidEmail1(client: Client, email: str, user):
 # provided 'email's domain is not in 'allowedEmailDomains'
 @pytest.mark.parametrize("client, email", [(("[ 'test.com' ]", "false"), "user2@test.de"), (("[ 'test.com' ]", "false"), "user2@sub.test.com")], indirect=["client"])
 def test_changeEmail_invalid_invalidEmail2(client: Client, email: str, user):
-    res = client.post("/api/user/changeEmail", headers=user,
+    res = client.post("/api/users/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": email})
     assert res.status_code == 400
     assert res.json["msg"] == f"'{email}' is not a valid email address"
@@ -557,7 +557,7 @@ def test_changeEmail_invalid_invalidEmail2(client: Client, email: str, user):
 # provided 'email' is already in use by another account
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_changeEmail_invalid_emailAlreadyInUse(client: Client, mockedSMTP, user):
-    res = client.post("/api/user/changeEmail", headers=user,
+    res = client.post("/api/users/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "admin@test.com"})
     assert res.status_code == 400 
     assert res.json["msg"] == "E-Mail is already used by another account"
@@ -569,7 +569,7 @@ def test_changeEmail_invalid_emailAlreadyInUse(client: Client, mockedSMTP, user)
 # provided 'email' is the same as the current email
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_changeEmail_invalid_emailNotChanged(client: Client, mockedSMTP, user):
-    res = client.post("/api/user/changeEmail", headers=user,
+    res = client.post("/api/users/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user@test.com"})
     assert res.status_code == 400 
     assert res.json["msg"] == "E-Mail is already used by another account"
@@ -583,7 +583,7 @@ def test_changeEmail_invalid_emailNotChanged(client: Client, mockedSMTP, user):
 def test_changeEmail_invalid_brokenSMTP(client: Client, mockedSMTP, user):
     mockedSMTP.side_effect = smtplib.SMTPException
 
-    res = client.post("/api/user/changeEmail", headers=user,
+    res = client.post("/api/users/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user2@test.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "Failed to send activation email to user2@test.com. Email address may not exist"
@@ -596,7 +596,7 @@ def test_changeEmail_invalid_brokenSMTP(client: Client, mockedSMTP, user):
 # normal user modifies themselves
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_changeEmail_valid_nonAdmin(client: Client, mockedSMTP, user):
-    res = client.post("/api/user/changeEmail", headers=user,
+    res = client.post("/api/users/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user2@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully requested email address change. Please confirm your new address by clicking on the link provided in the email we just sent you"
@@ -614,7 +614,7 @@ def test_changeEmail_valid_nonAdmin(client: Client, mockedSMTP, user):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changeEmail_valid_admin(client: Client, mockedSMTP, admin):
     # admin user deletes other user
-    res = client.post("/api/user/changeEmail", headers=admin, data={
+    res = client.post("/api/users/changeEmail", headers=admin, data={
                       "password": "adminPassword1!", "newEmail": "user2@test.com", "emailModify": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully requested email address change. Please confirm your new address by clicking on the link provided in the email we just sent you"
@@ -635,7 +635,7 @@ def test_changeEmail_valid_admin(client: Client, mockedSMTP, admin):
 # user is alredy activated
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resendActivationEmail_invalid_alreadyActivated(client: Client, mockedSMTP, user):
-    res = client.get("/api/user/resendActivationEmail", headers=user)
+    res = client.get("/api/users/resendActivationEmail", headers=user)
     assert res.status_code == 400
     assert res.json["msg"] == "This user is already activated"
     assert res.json["errorType"] == "operation"
@@ -647,12 +647,12 @@ def test_resendActivationEmail_invalid_alreadyActivated(client: Client, mockedSM
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resendActivationEmail_invalid_brokenSMTP(client: Client, mockedSMTP, user):
     res = client.post(
-        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/users/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
     user2 = get_auth_headers(client, "user2@test.com", "user2Password1!")
 
     mockedSMTP.side_effect = smtplib.SMTPException
-    res = client.get("/api/user/resendActivationEmail", headers=user2)
+    res = client.get("/api/users/resendActivationEmail", headers=user2)
     assert res.status_code == 400
     assert res.json["msg"] == "Failed to send password reset email to user2@test.com."
 
@@ -664,11 +664,11 @@ def test_resendActivationEmail_invalid_brokenSMTP(client: Client, mockedSMTP, us
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resendActivationEmail_valid(client: Client, mockedSMTP, user):
     res = client.post(
-        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/users/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
     user2 = get_auth_headers(client, "user2@test.com", "user2Password1!")
 
-    res = client.get("/api/user/resendActivationEmail", headers=user2)
+    res = client.get("/api/users/resendActivationEmail", headers=user2)
     assert res.status_code == 200
     assert res.json["msg"] == "We have sent a new password reset email to user2@test.com. Please check your emails"
 
@@ -688,12 +688,12 @@ def test_resendActivationEmail_valid(client: Client, mockedSMTP, user):
 # successful call and login tokesn invalidated
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_invalidateAllTokens_valid(client: Client, user):
-    res = client.post("/api/user/invalidateAllTokens", headers=user)
+    res = client.post("/api/users/invalidateAllTokens", headers=user)
     assert res.status_code == 200
     assert res.json["msg"] == "You have successfully been logged out accross all your devices"
 
     #check if header is still valid
-    res = client.get("/api/user/info", headers=user)
+    res = client.get("/api/users/info", headers=user)
     # the request should fail because the jwt token has been revoked
     # by changing the user password
     assert 400 <= res.status_code < 500
@@ -704,11 +704,11 @@ def test_invalidateAllTokens_valid(client: Client, user):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changePassword_revokes_session(client: Client, user):
     # assume this succeeds, that's not what we're testing here
-    res = client.post("/api/user/changePassword", headers=user,
+    res = client.post("/api/users/changePassword", headers=user,
                       data={"password": "userPassword1!", "newPassword": "user2Password1!"})
     assert res.status_code == 200
 
-    res = client.get("/api/user/info", headers=user)
+    res = client.get("/api/users/info", headers=user)
     # the request should fail because the jwt token has been revoked
     # by changing the user password
     assert 400 <= res.status_code < 500
@@ -716,7 +716,7 @@ def test_changePassword_revokes_session(client: Client, user):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_changeEmail_revokes_session(client: Client, mockedSMTP, user):
     # assume this succeeds, that's not what we're testing here
-    res = client.post("/api/user/changeEmail", headers=user,
+    res = client.post("/api/users/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user2@test.com"})
     assert res.status_code == 200
 
@@ -724,17 +724,17 @@ def test_changeEmail_revokes_session(client: Client, mockedSMTP, user):
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.post("/api/user/activate", data={"token": token})
+    res = client.post("/api/users/activate", data={"token": token})
     assert res.status_code == 200
 
-    res = client.get("/api/user/info", headers=user)
+    res = client.get("/api/users/info", headers=user)
     # the request should fail because the jwt token has been revoked.
     # by changing the user password
     assert 400 <= res.status_code < 500
 
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_corsSupport(client: Client, user):
-    res = client.get("/api/user/info", headers=user)
+    res = client.get("/api/users/info", headers=user)
     assert res.status_code == 200
 
     assert res.headers.get("Access-Control-Allow-Origin") == "*"

--- a/tests/test_user-management.py
+++ b/tests/test_user-management.py
@@ -6,7 +6,7 @@ from tests import get_auth_headers
 @pytest.mark.parametrize("client", [("[]", "true"), ("[ 'test.com' ]", "true"), ("[ 'test.com', 'sub.test.com' ]", "true")], indirect=True)
 def test_signup_invalid_disabledSignup(client: Client):
     res = client.post(
-        "/api/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Signup of new accounts is disabled on this server"
     assert res.json["errorType"] == "serverConfig"
@@ -14,7 +14,7 @@ def test_signup_invalid_disabledSignup(client: Client):
 # missing form data
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_signup_invalid_missingFormData(client: Client):
-    res = client.post("/api/signup")
+    res = client.post("/api/user/signup")
     # leads to a flask error
     assert 400 <= res.status_code < 500
 
@@ -22,7 +22,7 @@ def test_signup_invalid_missingFormData(client: Client):
 @pytest.mark.parametrize("client, email", [(("[]", "false"), "abcdefg"), (("[]", "false"), "user2"), (("[]", "false"), "user2@test"), (("[]", "false"), "user2@test."), (("[]", "false"), "@test.com")], indirect=["client"])
 def test_signup_invalid_invalidEmail1(client: Client, email: str):
     res = client.post(
-        "/api/signup", data={"email": email, "password": "user2Password1!"})
+        "/api/user/signup", data={"email": email, "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == f"'{email}' is not a valid email address"
     assert res.json["allowedEmailDomains"] == []
@@ -32,7 +32,7 @@ def test_signup_invalid_invalidEmail1(client: Client, email: str):
 @pytest.mark.parametrize("client, email", [(("[ 'test.com' ]", "false"), "user2@test.de"), (("[ 'test.com' ]", "false"), "user2@sub.test.com")], indirect=["client"])
 def test_signup_invalid_invalidEmail2(client: Client, email: str):
     res = client.post(
-        "/api/signup", data={"email": email, "password": "user2Password1!"})
+        "/api/user/signup", data={"email": email, "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == f"'{email}' is not a valid email address"
     assert res.json["allowedEmailDomains"] == [ 'test.com' ]
@@ -42,7 +42,7 @@ def test_signup_invalid_invalidEmail2(client: Client, email: str):
 @pytest.mark.parametrize("client, password", [(("[]", "false"), "user2"), (("[]", "false"), "tooShort58!"), (("[]", "false"), "thispasswordhasnouppercasechars390!"), (("[]", "false"), "THISPASSWORDHASNOLOWERCASE$%=56"), (("[]", "false"), "ThisPasswordHasNoNumbers!"), (("[]", "false"), "ThisPasswordHasNoSymbols123"), (("[]", "false"), "thispasswordhasnouppercasechars390!")], indirect=["client"])
 def test_signup_invalid_invalidPassword(client: Client, password: str):
     res = client.post(
-        "/api/signup", data={"email": "user2@test.com", "password": password})
+        "/api/user/signup", data={"email": "user2@test.com", "password": password})
     assert res.status_code == 400
     assert res.json["msg"] == "Password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"
     assert res.json["errorType"] == "password"
@@ -51,7 +51,7 @@ def test_signup_invalid_invalidPassword(client: Client, password: str):
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_signup_invalid_emailAlreadyInUse(client: Client):
     res = client.post(
-        "/api/signup", data={"email": "user@test.com", "password": "user2Password1!"})
+        "/api/user/signup", data={"email": "user@test.com", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "E-Mail is already used by another account"
     assert res.json["errorType"] == "email"
@@ -62,7 +62,7 @@ def test_signup_invalid_brokenSMTP(client: Client, mockedSMTP):
     mockedSMTP.side_effect = smtplib.SMTPException
 
     res = client.post(
-        "/api/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Failed to send activation email to user2@test.com. Email address may not exist"
     assert res.json["errorType"] == "email"
@@ -74,7 +74,7 @@ def test_signup_invalid_brokenSMTP(client: Client, mockedSMTP):
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
 def test_signup_valid(client: Client, mockedSMTP):
     res = client.post(
-        "/api/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successful signup for user2@test.com. Please activate your account be clicking on the link provided in the email we just sent you"
 
@@ -94,7 +94,7 @@ def test_signup_valid(client: Client, mockedSMTP):
 #no token in query string
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_invalid_noToken(client: Client):
-    res = client.get("/api/activate")
+    res = client.post("/api/user/activate")
     assert res.status_code == 400
     assert res.json["msg"] == "You need a token to activate a users email"
     assert res.json["errorType"] == "auth"
@@ -103,7 +103,7 @@ def test_activate_invalid_noToken(client: Client):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_invalid_invalidToken(client: Client):
     #hint: tokens are 127 characters long
-    res = client.get("/api/activate", query_string={"token": "safjdDkdf8239hf839fdFsdfas.FDSf239dHF001fdhFDFfuisagu.6asdjgKOPFDdfsFDDgufg898989898dU89789fFDDGudufFD123449FGDjhgdfhgfua5438FD"})
+    res = client.post("/api/user/activate", data={"token": "safjdDkdf8239hf839fdFsdfas.FDSf239dHF001fdhFDFfuisagu.6asdjgKOPFDdfsFDDgufg898989898dU89789fFDDGudufFD123449FGDjhgdfhgfua5438FD"})
     assert res.status_code == 400
     assert res.json["msg"] == "Invalid or expired activation link"
     assert res.json["errorType"] == "auth"
@@ -112,7 +112,7 @@ def test_activate_invalid_invalidToken(client: Client):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_invalid_userDeleted(client: Client, mockedSMTP):
     res = client.post(
-        "/api/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
@@ -120,11 +120,11 @@ def test_activate_invalid_userDeleted(client: Client, mockedSMTP):
     token = tokenLine.partition("token=")[2]
 
     user2 = get_auth_headers(client, "user2@test.com", "user2Password1!")
-    res = client.post("/api/deleteUser", headers=user2,
+    res = client.post("/api/user/delete", headers=user2,
                       data={"password": "user2Password1!"})
     assert res.status_code == 200
 
-    res = client.get("/api/activate", query_string={"token": token})
+    res = client.post("/api/user/activate", data={"token": token})
     assert res.status_code == 400
     assert res.json["msg"] == "No user with email user2@test.com exists"
     assert res.json["errorType"] == "notInDatabase"
@@ -133,16 +133,16 @@ def test_activate_invalid_userDeleted(client: Client, mockedSMTP):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_invalid_userAlreadyActivated(client: Client, mockedSMTP):
     res = client.post(
-        "/api/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.get("/api/activate", query_string={"token": token})
+    res = client.post("/api/user/activate", data={"token": token})
     assert res.status_code == 200
 
-    res = client.get("/api/activate", query_string={"token": token})
+    res = client.post("/api/user/activate", data={"token": token})
     assert res.status_code == 400
     assert res.json["msg"] == "Account for user2@test.com is already activated"
     assert res.json["errorType"] == "operation"
@@ -152,21 +152,21 @@ def test_activate_invalid_userAlreadyActivated(client: Client, mockedSMTP):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_valid_signup(client: Client, mockedSMTP):
     res = client.post(
-        "/api/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.get("/api/activate", query_string={"token": token})
+    res = client.post("/api/user/activate", data={"token": token})
     assert res.status_code == 200
     assert res.json["msg"] == "Account user2@test.com activated"
 
 #valid after email address change
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_activate_valid_emailChange(client: Client, mockedSMTP, user):
-    res = client.post("/api/changeUserEmail", headers=user,
+    res = client.post("/api/user/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user2@test.com"})
     assert res.status_code == 200
 
@@ -174,7 +174,7 @@ def test_activate_valid_emailChange(client: Client, mockedSMTP, user):
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.get("/api/activate", query_string={"token": token})
+    res = client.post("/api/user/activate", data={"token": token})
     assert res.status_code == 200
     assert res.json["msg"] == "Account user2@test.com activated"
 
@@ -184,7 +184,7 @@ def test_activate_valid_tokenStaysValid(client: Client, mockedSMTP):
     email: str = "user2@test.com"
     password: str = "user2Password1!"
     signupRes = client.post(
-        "/api/signup", data={"email": email, "password": password})
+        "/api/user/signup", data={"email": email, "password": password})
     assert signupRes.status_code == 200
 
     user2 = get_auth_headers(client, email, password)
@@ -192,11 +192,11 @@ def test_activate_valid_tokenStaysValid(client: Client, mockedSMTP):
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
-    activateRes = client.get("/api/activate", query_string={"token": token})
+    activateRes = client.post("/api/user/activate", data={"token": token})
     assert activateRes.status_code == 200
 
-    userinfoRes = client.get("/api/userinfo", headers=user2)
-    assert userinfoRes.status_code == 200
+    infoRes = client.get("/api/user/info", headers=user2)
+    assert infoRes.status_code == 200
 
 
 
@@ -204,13 +204,13 @@ def test_activate_valid_tokenStaysValid(client: Client, mockedSMTP):
 # missing form data
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_login_invalid_missingFormData(client: Client):
-    res = client.post("/api/login")
+    res = client.post("/api/user/login")
     assert 400 <= res.status_code < 500
 
 # unknown email
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_login_invalid_unknownEmail(client: Client):
-    res = client.post("/api/login", data={"email": "", "password": "user2Password1!"})
+    res = client.post("/api/user/login", data={"email": "", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Incorrect credentials provided"
     assert res.json["errorType"] == "auth"
@@ -219,7 +219,7 @@ def test_login_invalid_unknownEmail(client: Client):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_login_invalid_wrongPassword(client: Client):
     res = client.post(
-        "/api/login", data={"email": "user@test.com", "password": "user2Password1!"})
+        "/api/user/login", data={"email": "user@test.com", "password": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Incorrect credentials provided"
     assert res.json["errorType"] == "auth"
@@ -230,7 +230,7 @@ def test_login_valid(client: Client):
     email = "user@test.com"
     password = "userPassword1!"
     response = client.post(
-        "/api/login", data={"email": email, "password": password})
+        "/api/user/login", data={"email": email, "password": password})
     assert response.status_code == 200
     assert response.json["msg"] == "Login successful"
     assert "access_token" in response.json
@@ -241,8 +241,8 @@ def test_login_valid(client: Client):
 # provided 'email' doesn't belong to any user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_requestPasswordReset_invalid_invalidEmail(client: Client, mockedSMTP):
-    res = client.post(
-        "/api/requestPasswordReset", data={"email": "user2@test.com", "password": "user2Password1!"})
+    res = client.get(
+        "/api/user/requestPasswordReset", query_string={"email": "user2@test.com"})
     #you shouldn't be able to see from the client side if an entered email belongs to a user or not
     assert res.status_code == 200
     assert res.json["msg"] == f"If an account with the address user2@test.com exists, then we sent a password reset email to this address. Please check your emails"
@@ -255,8 +255,8 @@ def test_requestPasswordReset_invalid_invalidEmail(client: Client, mockedSMTP):
 def test_requestPasswordReset_invalid_brokenSMTP(client: Client, mockedSMTP):
     mockedSMTP.side_effect = smtplib.SMTPException
 
-    res = client.post(
-        "/api/requestPasswordReset", data={"email": "user@test.com", "password": "userPassword1!"})
+    res = client.get(
+        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "Failed to send password reset email to user@test.com."
     assert res.json["errorType"] == "email"
@@ -266,8 +266,8 @@ def test_requestPasswordReset_invalid_brokenSMTP(client: Client, mockedSMTP):
 
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_requestPasswordReset_valid(client: Client, mockedSMTP):
-    res = client.post(
-        "/api/requestPasswordReset", data={"email": "user@test.com", "password": "userPassword1!"})
+    res = client.get(
+        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == f"If an account with the address user@test.com exists, then we sent a password reset email to this address. Please check your emails"
 
@@ -288,7 +288,7 @@ def test_requestPasswordReset_valid(client: Client, mockedSMTP):
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resetPassword_invalid_noToken(client: Client):
     res = client.post(
-        "/api/resetPassword", data={"newPassword": "user2Password1!"})
+        "/api/user/resetPassword", data={"newPassword": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "You need a token to reset a users password"
     assert res.json["errorType"] == "auth"
@@ -298,7 +298,7 @@ def test_resetPassword_invalid_noToken(client: Client):
 def test_resetPassword_invalid_invalidToken(client: Client):
     #hint: tokens are 127 characters long
     res = client.post(
-        "/api/resetPassword", query_string={"token": "safjdDkdf8239hf839fdFsdfas.FDSf239dHF001fdhFDFfuisagu.6asdjgKOPFDdfsFDDgufg898989898dU89789fFDDGudufFD123449FGDjhgdfhgfua5438FD"}, data={"newPassword": "user2Password1!"})
+        "/api/user/resetPassword", data={"token": "safjdDkdf8239hf839fdFsdfas.FDSf239dHF001fdhFDFfuisagu.6asdjgKOPFDdfsFDDgufg898989898dU89789fFDDGudufFD123449FGDjhgdfhgfua5438FD", "newPassword": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Invalid or expired password reset link"
     assert res.json["errorType"] == "auth"
@@ -306,8 +306,8 @@ def test_resetPassword_invalid_invalidToken(client: Client):
 # provided 'password' does not fit criteria
 @pytest.mark.parametrize("client, password", [(("[]", "false"), "user2"), (("[]", "false"), "tooShort58!"), (("[]", "false"), "thispasswordhasnouppercasechars390!"), (("[]", "false"), "THISPASSWORDHASNOLOWERCASE$%=56"), (("[]", "false"), "ThisPasswordHasNoNumbers!"), (("[]", "false"), "ThisPasswordHasNoSymbols123"), (("[]", "false"), "thispasswordhasnouppercasechars390!")], indirect=["client"])
 def test_resetPassword_invalid_invalidPassword(client: Client, mockedSMTP, password: str):
-    res = client.post(
-        "/api/requestPasswordReset", data={"email": "user@test.com", "password": "userPassword1!"})
+    res = client.get(
+        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
@@ -315,7 +315,7 @@ def test_resetPassword_invalid_invalidPassword(client: Client, mockedSMTP, passw
     token = tokenLine.partition("token=")[2]
 
     res = client.post(
-        "/api/resetPassword", query_string={"token": token}, data={"newPassword": password})
+        "/api/user/resetPassword", query_string={}, data={"token": token, "newPassword": password})
     assert res.status_code == 400
     assert res.json["msg"] == "Password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"
     assert res.json["errorType"] == "password"
@@ -323,28 +323,28 @@ def test_resetPassword_invalid_invalidPassword(client: Client, mockedSMTP, passw
 #user deleted before password reset
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resetPassword_invalid_userDeleted(client: Client, mockedSMTP, user):
-    res = client.post(
-        "/api/requestPasswordReset", data={"email": "user@test.com", "password": "userPassword1!"})
+    res = client.get(
+        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.post("/api/deleteUser", headers=user,
+    res = client.post("/api/user/delete", headers=user,
                       data={"password": "userPassword1!"})
     assert res.status_code == 200
 
     res = client.post(
-        "/api/resetPassword", query_string={"token": token}, data={"newPassword": "user2Password1!"})
+        "/api/user/resetPassword", data={"token": token, "newPassword": "user2Password1!"})
     assert res.status_code == 400
     assert res.json["msg"] == "Unknown email address user@test.com"
     assert res.json["errorType"] == "notInDatabase"
 
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resetPassword_valid(client: Client, mockedSMTP):
-    res = client.post(
-        "/api/requestPasswordReset", data={"email": "user@test.com", "password": "userPassword1!"})
+    res = client.get(
+        "/api/user/requestPasswordReset", query_string={"email": "user@test.com"})
     assert res.status_code == 200
 
     msgBody = mockedSMTP.mock_calls[3][1][0].get_content()
@@ -352,7 +352,7 @@ def test_resetPassword_valid(client: Client, mockedSMTP):
     token = tokenLine.partition("token=")[2]
 
     res = client.post(
-        "/api/resetPassword", query_string={"token": token}, data={"newPassword": "user2Password1!"})
+        "/api/user/resetPassword", data={"token": token, "newPassword": "user2Password1!"})
     assert res.status_code == 200
     assert res.json["msg"] == "password changed successfully"
 
@@ -361,8 +361,8 @@ def test_resetPassword_valid(client: Client, mockedSMTP):
 
 # non-admins can't access other users' infos
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_userinfo_invalid_noPermissions(client: Client, user):
-    res = client.get("/api/userinfo", headers=user,
+def test_info_invalid_noPermissions(client: Client, user):
+    res = client.get("/api/user/info", headers=user,
                      query_string={"email": "admin@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "You don't have permission to view other accounts' user info"
@@ -370,8 +370,8 @@ def test_userinfo_invalid_noPermissions(client: Client, user):
 
 # can't access non-existent user info
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_userinfo_invalid_wrongEmail(client: Client, admin):
-    res = client.get("/api/userinfo", headers=admin,
+def test_info_invalid_wrongEmail(client: Client, admin):
+    res = client.get("/api/user/info", headers=admin,
                      query_string={"email": "fake@test.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "No user exists with that email"
@@ -380,22 +380,22 @@ def test_userinfo_invalid_wrongEmail(client: Client, admin):
 
 # non-admins can access their own user info
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_userinfo_valid_nonAdmins(client: Client, user):
-    res = client.get("/api/userinfo", headers=user)
+def test_info_valid_nonAdmins(client: Client, user):
+    res = client.get("/api/user/info", headers=user)
     assert res.status_code == 200
     assert res.json["email"] == "user@test.com"
     assert res.json["is_admin"] == False
 
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_userinfo_valid_admins(client: Client, admin):
+def test_info_valid_admins(client: Client, admin):
     # admins can also access their own user info
-    res = client.get("/api/userinfo", headers=admin)
+    res = client.get("/api/user/info", headers=admin)
     assert res.status_code == 200
     assert res.json["email"] == "admin@test.com"
     assert res.json["is_admin"] == True
 
     # admins can access other users' info
-    res = client.get("/api/userinfo", headers=admin,
+    res = client.get("/api/user/info", headers=admin,
                      query_string={"email": "user@test.com"})
     assert res.status_code == 200
     assert res.json["email"] == "user@test.com"
@@ -406,8 +406,8 @@ def test_userinfo_valid_admins(client: Client, admin):
 
 # wrong password
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_deleteUser_invalid_wrongPassword(client: Client, user):
-    res = client.post("/api/deleteUser", headers=user,
+def test_delete_invalid_wrongPassword(client: Client, user):
+    res = client.post("/api/user/delete", headers=user,
                       data={"password": "user2Password1!"})
     assert res.status_code == 403
     assert res.json["msg"] == "Incorrect password provided"
@@ -415,8 +415,8 @@ def test_deleteUser_invalid_wrongPassword(client: Client, user):
 
 # normal user who tries to delete other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_deleteUser_invalid_noPermissions(client: Client, user):
-    res = client.post("/api/deleteUser", headers=user,
+def test_delete_invalid_noPermissions(client: Client, user):
+    res = client.post("/api/user/delete", headers=user,
                       data={"password": "userPassword1!", "emailModify": "admin@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "You don't have permission to modify other users"
@@ -424,8 +424,8 @@ def test_deleteUser_invalid_noPermissions(client: Client, user):
 
 # admin user who tries to delete other user, but email is invalid
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_deleteUser_invalid_wrongEmail(client: Client, admin):
-    res = client.post("/api/deleteUser", headers=admin,
+def test_delete_invalid_wrongEmail(client: Client, admin):
+    res = client.post("/api/user/delete", headers=admin,
                       data={"password": "adminPassword1!", "emailModify": "abc@xyz.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "No user exists with that email"
@@ -434,16 +434,16 @@ def test_deleteUser_invalid_wrongEmail(client: Client, admin):
 
 # normal user deletes themselves
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_deleteUser_valid_nonAdmins(client: Client, user):
-    res = client.post("/api/deleteUser", headers=user,
+def test_delete_valid_nonAdmins(client: Client, user):
+    res = client.post("/api/user/delete", headers=user,
                       data={"password": "userPassword1!"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully deleted user with email user@test.com"
 
 # admin user deletes other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_deleteUser_valid_Admins(client: Client, admin):
-    res = client.post("/api/deleteUser", headers=admin,
+def test_delete_valid_Admins(client: Client, admin):
+    res = client.post("/api/user/delete", headers=admin,
                       data={"password": "adminPassword1!", "emailModify": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully deleted user with email user@test.com"
@@ -453,8 +453,8 @@ def test_deleteUser_valid_Admins(client: Client, admin):
 
 # wrong password
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserPassword_invalid_wrongPassword(client: Client, user):
-    res = client.post("/api/changeUserPassword", headers=user,
+def test_changePassword_invalid_wrongPassword(client: Client, user):
+    res = client.post("/api/user/changePassword", headers=user,
                       data={"password": "userPassword2!", "newPassword": "user2Password1!"})
     assert res.status_code == 403
     assert res.json["msg"] == "Incorrect password provided"
@@ -462,8 +462,8 @@ def test_changeUserPassword_invalid_wrongPassword(client: Client, user):
 
 # normal user who tries to modify other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserPassword_invalid_noPermissions(client: Client, user):
-    res = client.post("/api/changeUserPassword", headers=user, data={
+def test_changePassword_invalid_noPermissions(client: Client, user):
+    res = client.post("/api/user/changePassword", headers=user, data={
                       "password": "userPassword1!", "newPassword": "user2Password1!", "emailModify": "admin@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "You don't have permission to modify other users"
@@ -471,8 +471,8 @@ def test_changeUserPassword_invalid_noPermissions(client: Client, user):
 
 # admin user who tries to modify other user, but email is invalid
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserPassword_invalid_wrongEmail(client: Client, admin):
-    res = client.post("/api/changeUserPassword", headers=admin, data={
+def test_changePassword_invalid_wrongEmail(client: Client, admin):
+    res = client.post("/api/user/changePassword", headers=admin, data={
                       "password": "adminPassword1!", "newPassword": "adminPassword2!", "emailModify": "abc@xyz.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "No user exists with that email"
@@ -480,8 +480,8 @@ def test_changeUserPassword_invalid_wrongEmail(client: Client, admin):
 
 #newPassword does not meet criteria
 @pytest.mark.parametrize("client, password", [(("[]", "false"), "user2"), (("[]", "false"), "tooShort58!"), (("[]", "false"), "thispasswordhasnouppercasechars390!"), (("[]", "false"), "THISPASSWORDHASNOLOWERCASE$%=56"), (("[]", "false"), "ThisPasswordHasNoNumbers!"), (("[]", "false"), "ThisPasswordHasNoSymbols123"), (("[]", "false"), "thispasswordhasnouppercasechars390!")], indirect=["client"])
-def test_changeUserPassword_invalid_invalidPassword(client: Client, password: str, user):
-    res = client.post("/api/changeUserPassword", headers=user,
+def test_changePassword_invalid_invalidPassword(client: Client, password: str, user):
+    res = client.post("/api/user/changePassword", headers=user,
                       data={"password": "userPassword1!", "newPassword": password})
     assert res.status_code == 400
     assert res.json["msg"] == "Password invalid. The password needs to have at least one lowercase letter, uppercase letter, number, special character and at least 12 characters in total"
@@ -490,16 +490,16 @@ def test_changeUserPassword_invalid_invalidPassword(client: Client, password: st
 
 # normal user modifies themselves
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserPassword_valid_normal(client: Client, user):
-    res = client.post("/api/changeUserPassword", headers=user,
+def test_changePassword_valid_normal(client: Client, user):
+    res = client.post("/api/user/changePassword", headers=user,
                       data={"password": "userPassword1!", "newPassword": "user2Password1!"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully updated user password"
 
 # admin user deletes other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserPassword_valid_admin(client: Client, admin):
-    res = client.post("/api/changeUserPassword", headers=admin, data={
+def test_changePassword_valid_admin(client: Client, admin):
+    res = client.post("/api/user/changePassword", headers=admin, data={
                       "password": "adminPassword1!", "newPassword": "admin2Password!", "emailModify": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully updated user password"
@@ -509,8 +509,8 @@ def test_changeUserPassword_valid_admin(client: Client, admin):
 
 # wrong password
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserEmail_invalid_wrongPassword(client: Client, user):
-    res = client.post("/api/changeUserEmail", headers=user,
+def test_changeEmail_invalid_wrongPassword(client: Client, user):
+    res = client.post("/api/user/changeEmail", headers=user,
                       data={"password": "userPassword2!", "newEmail": "user2@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "Incorrect password provided"
@@ -518,8 +518,8 @@ def test_changeUserEmail_invalid_wrongPassword(client: Client, user):
 
 # normal user who tries to modify other user
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserEmail_invalid_noPermissions(client: Client, user):
-    res = client.post("/api/changeUserEmail", headers=user, data={
+def test_changeEmail_invalid_noPermissions(client: Client, user):
+    res = client.post("/api/user/changeEmail", headers=user, data={
                       "password": "userPassword1!", "newEmail": "user2@test.com", "emailModify": "admin@test.com"})
     assert res.status_code == 403
     assert res.json["msg"] == "You don't have permission to modify other users"
@@ -527,8 +527,8 @@ def test_changeUserEmail_invalid_noPermissions(client: Client, user):
 
 # admin user who tries to modify other user, but email is invalid
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserEmail_invalid_wrongEmail(client: Client, admin):
-    res = client.post("/api/changeUserEmail", headers=admin, data={
+def test_changeEmail_invalid_wrongEmail(client: Client, admin):
+    res = client.post("/api/user/changeEmail", headers=admin, data={
                       "password": "adminPassword1!", "newEmail": "abc2@xyz.com", "emailModify": "abc@xyz.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "No user exists with that email"
@@ -536,8 +536,8 @@ def test_changeUserEmail_invalid_wrongEmail(client: Client, admin):
 
 # provided 'email' is not an email address
 @pytest.mark.parametrize("client, email", [(("[]", "false"), "abcdefg"), (("[]", "false"), "user2"), (("[]", "false"), "user2@test"), (("[]", "false"), "user2@test."), (("[]", "false"), "@test.com")], indirect=["client"])
-def test_changeUserEmail_invalid_invalidEmail1(client: Client, email: str, user):
-    res = client.post("/api/changeUserEmail", headers=user,
+def test_changeEmail_invalid_invalidEmail1(client: Client, email: str, user):
+    res = client.post("/api/user/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": email})
     assert res.status_code == 400
     assert res.json["msg"] == f"'{email}' is not a valid email address"
@@ -546,8 +546,8 @@ def test_changeUserEmail_invalid_invalidEmail1(client: Client, email: str, user)
 
 # provided 'email's domain is not in 'allowedEmailDomains'
 @pytest.mark.parametrize("client, email", [(("[ 'test.com' ]", "false"), "user2@test.de"), (("[ 'test.com' ]", "false"), "user2@sub.test.com")], indirect=["client"])
-def test_changeUserEmail_invalid_invalidEmail2(client: Client, email: str, user):
-    res = client.post("/api/changeUserEmail", headers=user,
+def test_changeEmail_invalid_invalidEmail2(client: Client, email: str, user):
+    res = client.post("/api/user/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": email})
     assert res.status_code == 400
     assert res.json["msg"] == f"'{email}' is not a valid email address"
@@ -556,8 +556,8 @@ def test_changeUserEmail_invalid_invalidEmail2(client: Client, email: str, user)
 
 # provided 'email' is already in use by another account
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
-def test_changeUserEmail_invalid_emailAlreadyInUse(client: Client, mockedSMTP, user):
-    res = client.post("/api/changeUserEmail", headers=user,
+def test_changeEmail_invalid_emailAlreadyInUse(client: Client, mockedSMTP, user):
+    res = client.post("/api/user/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "admin@test.com"})
     assert res.status_code == 400 
     assert res.json["msg"] == "E-Mail is already used by another account"
@@ -568,8 +568,8 @@ def test_changeUserEmail_invalid_emailAlreadyInUse(client: Client, mockedSMTP, u
 
 # provided 'email' is the same as the current email
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
-def test_changeUserEmail_invalid_emailNotChanged(client: Client, mockedSMTP, user):
-    res = client.post("/api/changeUserEmail", headers=user,
+def test_changeEmail_invalid_emailNotChanged(client: Client, mockedSMTP, user):
+    res = client.post("/api/user/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user@test.com"})
     assert res.status_code == 400 
     assert res.json["msg"] == "E-Mail is already used by another account"
@@ -580,10 +580,10 @@ def test_changeUserEmail_invalid_emailNotChanged(client: Client, mockedSMTP, use
 
 # email couldn't be sent
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
-def test_changeUserEmail_invalid_brokenSMTP(client: Client, mockedSMTP, user):
+def test_changeEmail_invalid_brokenSMTP(client: Client, mockedSMTP, user):
     mockedSMTP.side_effect = smtplib.SMTPException
 
-    res = client.post("/api/changeUserEmail", headers=user,
+    res = client.post("/api/user/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user2@test.com"})
     assert res.status_code == 400
     assert res.json["msg"] == "Failed to send activation email to user2@test.com. Email address may not exist"
@@ -595,8 +595,8 @@ def test_changeUserEmail_invalid_brokenSMTP(client: Client, mockedSMTP, user):
 
 # normal user modifies themselves
 @pytest.mark.parametrize("client", [("[]", "false"), ("[ 'test.com' ]", "false"), ("[ 'test.com', 'sub.test.com' ]", "false")], indirect=True)
-def test_changeUserEmail_valid_nonAdmin(client: Client, mockedSMTP, user):
-    res = client.post("/api/changeUserEmail", headers=user,
+def test_changeEmail_valid_nonAdmin(client: Client, mockedSMTP, user):
+    res = client.post("/api/user/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user2@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully requested email address change. Please confirm your new address by clicking on the link provided in the email we just sent you"
@@ -612,9 +612,9 @@ def test_changeUserEmail_valid_nonAdmin(client: Client, mockedSMTP, user):
     assert body.count("https://example.com/activate?token=")
 
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserEmail_valid_admin(client: Client, mockedSMTP, admin):
+def test_changeEmail_valid_admin(client: Client, mockedSMTP, admin):
     # admin user deletes other user
-    res = client.post("/api/changeUserEmail", headers=admin, data={
+    res = client.post("/api/user/changeEmail", headers=admin, data={
                       "password": "adminPassword1!", "newEmail": "user2@test.com", "emailModify": "user@test.com"})
     assert res.status_code == 200
     assert res.json["msg"] == "Successfully requested email address change. Please confirm your new address by clicking on the link provided in the email we just sent you"
@@ -635,7 +635,7 @@ def test_changeUserEmail_valid_admin(client: Client, mockedSMTP, admin):
 # user is alredy activated
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resendActivationEmail_invalid_alreadyActivated(client: Client, mockedSMTP, user):
-    res = client.get("/api/resendActivationEmail", headers=user)
+    res = client.get("/api/user/resendActivationEmail", headers=user)
     assert res.status_code == 400
     assert res.json["msg"] == "This user is already activated"
     assert res.json["errorType"] == "operation"
@@ -647,12 +647,12 @@ def test_resendActivationEmail_invalid_alreadyActivated(client: Client, mockedSM
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resendActivationEmail_invalid_brokenSMTP(client: Client, mockedSMTP, user):
     res = client.post(
-        "/api/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
     user2 = get_auth_headers(client, "user2@test.com", "user2Password1!")
 
     mockedSMTP.side_effect = smtplib.SMTPException
-    res = client.get("/api/resendActivationEmail", headers=user2)
+    res = client.get("/api/user/resendActivationEmail", headers=user2)
     assert res.status_code == 400
     assert res.json["msg"] == "Failed to send password reset email to user2@test.com."
 
@@ -664,11 +664,11 @@ def test_resendActivationEmail_invalid_brokenSMTP(client: Client, mockedSMTP, us
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_resendActivationEmail_valid(client: Client, mockedSMTP, user):
     res = client.post(
-        "/api/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
+        "/api/user/signup", data={"email": "user2@test.com", "password": "user2Password1!"})
     assert res.status_code == 200
     user2 = get_auth_headers(client, "user2@test.com", "user2Password1!")
 
-    res = client.get("/api/resendActivationEmail", headers=user2)
+    res = client.get("/api/user/resendActivationEmail", headers=user2)
     assert res.status_code == 200
     assert res.json["msg"] == "We have sent a new password reset email to user2@test.com. Please check your emails"
 
@@ -688,12 +688,12 @@ def test_resendActivationEmail_valid(client: Client, mockedSMTP, user):
 # successful call and login tokesn invalidated
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_invalidateAllTokens_valid(client: Client, user):
-    res = client.get("/api/invalidateAllTokens", headers=user)
+    res = client.get("/api/user/invalidateAllTokens", headers=user)
     assert res.status_code == 200
     assert res.json["msg"] == "You have successfully been logged out accross all your devices"
 
     #check if header is still valid
-    res = client.get("/api/userinfo", headers=user)
+    res = client.get("/api/user/info", headers=user)
     # the request should fail because the jwt token has been revoked
     # by changing the user password
     assert 400 <= res.status_code < 500
@@ -702,21 +702,21 @@ def test_invalidateAllTokens_valid(client: Client, user):
 
 
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserPassword_revokes_session(client: Client, user):
+def test_changePassword_revokes_session(client: Client, user):
     # assume this succeeds, that's not what we're testing here
-    res = client.post("/api/changeUserPassword", headers=user,
+    res = client.post("/api/user/changePassword", headers=user,
                       data={"password": "userPassword1!", "newPassword": "user2Password1!"})
     assert res.status_code == 200
 
-    res = client.get("/api/userinfo", headers=user)
+    res = client.get("/api/user/info", headers=user)
     # the request should fail because the jwt token has been revoked
     # by changing the user password
     assert 400 <= res.status_code < 500
 
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
-def test_changeUserEmail_revokes_session(client: Client, mockedSMTP, user):
+def test_changeEmail_revokes_session(client: Client, mockedSMTP, user):
     # assume this succeeds, that's not what we're testing here
-    res = client.post("/api/changeUserEmail", headers=user,
+    res = client.post("/api/user/changeEmail", headers=user,
                       data={"password": "userPassword1!", "newEmail": "user2@test.com"})
     assert res.status_code == 200
 
@@ -724,17 +724,17 @@ def test_changeUserEmail_revokes_session(client: Client, mockedSMTP, user):
     tokenLine = msgBody.split('\n')[2]
     token = tokenLine.partition("token=")[2]
 
-    res = client.get("/api/activate", query_string={"token": token})
+    res = client.post("/api/user/activate", data={"token": token})
     assert res.status_code == 200
 
-    res = client.get("/api/userinfo", headers=user)
+    res = client.get("/api/user/info", headers=user)
     # the request should fail because the jwt token has been revoked.
     # by changing the user password
     assert 400 <= res.status_code < 500
 
 @pytest.mark.parametrize("client", [("[]", "false")], indirect=True)
 def test_corsSupport(client: Client, user):
-    res = client.get("/api/userinfo", headers=user)
+    res = client.get("/api/user/info", headers=user)
     assert res.status_code == 200
 
     assert res.headers.get("Access-Control-Allow-Origin") == "*"


### PR DESCRIPTION
This is whats new:

- all negative responses made by us now contain an errorTypes attribute. The errorTypes are defined as follows:
  - serverConfig
      - error due to configuration of server 
      - e.g.: disableSignup is set in config
  - email
      - error due to email being invalid in some way
      - e.g. when setting email in signup, changeEmail
      - not for login or similar, only when it is NOT an authentication paramter! (see auth for that)!
  - password
      - error due to password being invalid in some way 
      - e.g. when signup, changePassword (like password too short)
      - not for login or any kind of authentication, only when it is NOT an authentication parameter (see auth for that)!
  - permission
      - user doesn't have permission to access this route/resource/feature
      - e.g. admin exclusive routes, user tries to modify other users or user not activated even though that is required for route
      - often combined with http status code 403
      - not for authentication failures, see auth for that!
  - auth
      - authentication failed for some reason
      - e.g. invalid credentials, invalid password, invalid token, etc.
  - notInDatabase
      - requested ressource is not in database 
      - e.g. when user with specified email couldn't be found in database 
  - operation
      - invalid operation at this time (e.g. some condition for this operation that is not part of request itself is not met)
      - e.g. activate_user when user is already activated
- add three custom function decorators for api routes:
  - activatedRequired: Checks wheither the user is activated before they can use the route. Mainly for upcoming job management routes
  - confirmIdentity: Checks the password from a provided 'password' form attribute (additionally to JWT Token). For routes that have serious consequences like deleteUser, changeUserEmail, changeUserPassword
  - emailModifyForAdmins: If there is a form attribute called 'emailModify': Checks if user is admin and if the specified user exists. If yes, returns user specified with 'emailModify'. If this attribute doesn't exist it will just return the currently logged in user. Useful for routes like changeUserEmail, changeUserPassword that can be used both by admins and non-admins
- Add CORS support: All routes will have the 'Access-Control-Allow-Origin' set to '*' and thus allowing all origins to access it
- add new route resendActivationEmail: resending this mail over changeUserEmail route is awkward, this should have a dedicated route
- add new route invalidateAllTokens: invalidates all existing tokens of the current user thus logging all its sessions out
- sanitize usage of get/post among all routes
  - get: for safe and idempotent routes
  - post: for routes that are neither safe nor idempotent
  - (put: for routes that are not safe but idempotent, not used currently)
- move all user management routes to /api/user subroute to avoid repeated usage of 'user' in route name and to make it coherent with /api/jobs and /api/runners
- tests
  - move all tests of user management into its own file called test_user-management so that tests for the jobs and runner apis can be separated more easily in the future 
  - add new tests for new routes,
  - add new test cases for existing routes (that check for bugs I found)
  - adjust tests for new features/behavior
- fixing various other bugs

This required the following new dependency:
- flask-cors: for CORS support