### PR TITLE
Pin pnpm@10

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app/frontend
 
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 
 COPY . /app
 


### PR DESCRIPTION
Recent CI failures seem to be caused by pnpm@11 introducing backwards incompatible changes. The commit fixes it to 10 for the moment.